### PR TITLE
Removed audio, neopixel, can2 from interconnect

### DIFF
--- a/documentation/electrical.md
+++ b/documentation/electrical.md
@@ -51,15 +51,15 @@ HiRose DF17 30 pin
 | 1 | V<sub>batt</batt> | 3.3V | 28 |
 | 2 | GND | 5V | 27 |
 | 3 | GND | 5V | 26 |
-| 4 | RADIO TX | NEOPIXEL | 25 |
-| 5 | RADIO RX | AUDIO | 24 |
-| 6 | Unused | CAN1 HI | 23 |
-| 7 | Unused | CAN1 LO | 22 |
-| 8 | GPS RX | GND | 21 |
-| 9 | GPS TX | GND | 20 |
-| 10 | 5V | CAN2 HI | 19 |
-| 11 | 3.3V | CAN2 LO | 18 |
-| 12 | 1PPS | 3.3V | 17 |
+| 4 | RADIO TX | Unused | 25 |
+| 5 | RADIO RX | Unused | 24 |
+| 6 | Unused | CAN HI | 23 |
+| 7 | Arm | CAN LO | 22 |
+| 8 | Unused | GND | 21 |
+| 9 | Unused | GND | 20 |
+| 10 | 5V | Unused | 19 |
+| 11 | 3.3V | Unused | 18 |
+| 12 | GPS PPS | 3.3V | 17 |
 | 13 | GND | Unused | 16 |
 | 14 | GND | Unused | 15 |
 

--- a/hardware/blaze_brain/blaze_brain.kicad_sch
+++ b/hardware/blaze_brain/blaze_brain.kicad_sch
@@ -5093,12 +5093,6 @@
 		(uuid "03f47d99-49d7-4213-8091-40dced9dc1dd")
 	)
 	(junction
-		(at 266.7 31.75)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "1dcbbcce-d453-4ebd-b421-b006bb9b20eb")
-	)
-	(junction
 		(at 251.46 102.87)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5259,6 +5253,10 @@
 		(uuid "1cdf68b8-91cd-4d2a-856f-edfc18456e9f")
 	)
 	(no_connect
+		(at 267.97 77.47)
+		(uuid "25bc05fd-4914-4ec4-8c84-caf2cc733e4e")
+	)
+	(no_connect
 		(at 242.57 53.34)
 		(uuid "2edec580-1c2b-4510-b9e3-8eb2a2efafce")
 	)
@@ -5273,6 +5271,10 @@
 	(no_connect
 		(at 242.57 88.9)
 		(uuid "3429ac87-4f00-4582-b3e4-d2a9e2c6a638")
+	)
+	(no_connect
+		(at 267.97 95.25)
+		(uuid "386fba87-fc87-4136-8529-7d85f04b9758")
 	)
 	(no_connect
 		(at 186.69 99.06)
@@ -5303,6 +5305,10 @@
 		(uuid "4a9a0573-eb32-4938-9550-7cb8e68a4bf9")
 	)
 	(no_connect
+		(at 267.97 31.75)
+		(uuid "4be41950-bced-4526-adf8-1c2f2314fc72")
+	)
+	(no_connect
 		(at 186.69 43.18)
 		(uuid "516a31b4-5809-4353-b1b3-8a7c6aaae049")
 	)
@@ -5323,8 +5329,20 @@
 		(uuid "5567adb1-88e6-447e-b6f9-23d5dec174b7")
 	)
 	(no_connect
+		(at 267.97 52.07)
+		(uuid "55bda05b-72ba-4121-b9a0-b809458f0548")
+	)
+	(no_connect
+		(at 267.97 54.61)
+		(uuid "5f426853-0cbe-4500-b7f7-44d26001471b")
+	)
+	(no_connect
 		(at 242.57 96.52)
 		(uuid "62fc57da-53f8-4e92-b493-fa228e33b296")
+	)
+	(no_connect
+		(at 267.97 34.29)
+		(uuid "66a68807-e990-4843-99a7-2a742cc51af9")
 	)
 	(no_connect
 		(at 242.57 58.42)
@@ -5341,6 +5359,10 @@
 	(no_connect
 		(at 267.97 72.39)
 		(uuid "72793ef7-e398-4117-874b-a2f35a73570b")
+	)
+	(no_connect
+		(at 267.97 92.71)
+		(uuid "8046ec74-70ef-465c-af7b-a4ca5906d22e")
 	)
 	(no_connect
 		(at 54.61 53.34)
@@ -5399,10 +5421,6 @@
 		(uuid "e83d5249-5f8f-42a9-b0a1-c4425c4012af")
 	)
 	(no_connect
-		(at 242.57 48.26)
-		(uuid "f0bcd0ca-85d6-4ecf-b0e4-0b1b011b18d6")
-	)
-	(no_connect
 		(at 186.69 55.88)
 		(uuid "f14d983e-3245-4c8a-ad1b-6954608e3c4c")
 	)
@@ -5417,6 +5435,10 @@
 	(no_connect
 		(at 242.57 101.6)
 		(uuid "f7ada476-d20b-4043-a6d5-a7fcd688730f")
+	)
+	(no_connect
+		(at 267.97 80.01)
+		(uuid "fd8dc49f-ce3e-4768-9955-faeba2e1ed26")
 	)
 	(wire
 		(pts
@@ -5470,13 +5492,13 @@
 	)
 	(wire
 		(pts
-			(xy 266.7 31.75) (xy 266.7 34.29)
+			(xy 262.89 87.63) (xy 267.97 87.63)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1094f447-ae4e-4db9-b44a-3e53f1c27f93")
+		(uuid "0b2339f2-6953-4061-814d-7fc25097cc60")
 	)
 	(wire
 		(pts
@@ -5630,6 +5652,16 @@
 	)
 	(wire
 		(pts
+			(xy 242.57 48.26) (xy 246.38 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "301eaf1e-8707-40ef-8954-385319d8a82a")
+	)
+	(wire
+		(pts
 			(xy 228.6 140.97) (xy 229.87 140.97)
 		)
 		(stroke
@@ -5670,13 +5702,13 @@
 	)
 	(wire
 		(pts
-			(xy 266.7 30.48) (xy 266.7 31.75)
+			(xy 262.89 90.17) (xy 267.97 90.17)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "3c87b652-f78b-4c91-966b-310d2f3615d5")
+		(uuid "43fee6f6-d33a-4273-b1a4-493364295b79")
 	)
 	(wire
 		(pts
@@ -5920,16 +5952,6 @@
 	)
 	(wire
 		(pts
-			(xy 266.7 31.75) (xy 267.97 31.75)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8e5fd238-96f6-4d08-a8fc-cfca52d489bc")
-	)
-	(wire
-		(pts
 			(xy 184.15 66.04) (xy 186.69 66.04)
 		)
 		(stroke
@@ -6037,16 +6059,6 @@
 			(type default)
 		)
 		(uuid "9cfc5121-49c8-4791-a396-da0377b7b022")
-	)
-	(wire
-		(pts
-			(xy 266.7 34.29) (xy 267.97 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9f7a78f0-089b-4a24-8b47-b5586065522d")
 	)
 	(wire
 		(pts
@@ -6270,6 +6282,16 @@
 	)
 	(wire
 		(pts
+			(xy 264.16 62.23) (xy 267.97 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca2379b1-91dc-4d32-b83f-50470b1cb5b3")
+	)
+	(wire
+		(pts
 			(xy 185.42 73.66) (xy 186.69 73.66)
 		)
 		(stroke
@@ -6350,6 +6372,16 @@
 	)
 	(wire
 		(pts
+			(xy 259.08 41.91) (xy 267.97 41.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e138557c-52ab-4340-bbce-70dc6ad16632")
+	)
+	(wire
+		(pts
 			(xy 251.46 143.51) (xy 252.73 143.51)
 		)
 		(stroke
@@ -6420,6 +6452,16 @@
 	)
 	(wire
 		(pts
+			(xy 264.16 49.53) (xy 267.97 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee5ad782-8015-43d2-b757-a81cf935fe1a")
+	)
+	(wire
+		(pts
 			(xy 256.54 67.31) (xy 267.97 67.31)
 		)
 		(stroke
@@ -6437,6 +6479,16 @@
 			(type default)
 		)
 		(uuid "efa9476d-749b-439c-85ae-f39d3b2763f6")
+	)
+	(wire
+		(pts
+			(xy 259.08 44.45) (xy 267.97 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f1a7df17-f977-4e94-9fc0-22bfb0fa05ed")
 	)
 	(wire
 		(pts
@@ -6509,17 +6561,6 @@
 		)
 		(uuid "00681b41-e02e-47b2-9ce2-372e2483a1a3")
 	)
-	(label "NEOPIXEL"
-		(at 267.97 95.25 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "03df7c69-27f0-450f-a1dc-15e82454244d")
-	)
 	(label "MOSI"
 		(at 52.07 40.64 180)
 		(fields_autoplaced yes)
@@ -6530,28 +6571,6 @@
 			(justify right bottom)
 		)
 		(uuid "0777d7bd-20dc-496f-b89f-b999b42d7181")
-	)
-	(label "RX_GPS"
-		(at 267.97 54.61 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "117fa3c7-ebb8-45c1-a4dc-21317681be64")
-	)
-	(label "CAN2_LO"
-		(at 267.97 77.47 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "21210057-4b07-4fca-a8b4-3b5f7d75e17a")
 	)
 	(label "SCK"
 		(at 52.07 45.72 180)
@@ -6596,17 +6615,6 @@
 			(justify right bottom)
 		)
 		(uuid "400c11c5-be5a-41aa-9240-967e7b583f89")
-	)
-	(label "TX_GPS"
-		(at 267.97 52.07 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "410c4d81-9f33-45a1-bbff-679410b22bd2")
 	)
 	(label "MISO"
 		(at 184.15 66.04 180)
@@ -6695,17 +6703,6 @@
 			(justify right bottom)
 		)
 		(uuid "74153037-3ae3-497b-9cea-e154362f4585")
-	)
-	(label "AUDIO"
-		(at 267.97 92.71 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "741b8719-07e5-49ca-8314-afe801129ed7")
 	)
 	(label "MOSI"
 		(at 55.88 97.79 180)
@@ -6806,18 +6803,7 @@
 		)
 		(uuid "b1b2baae-adf4-436f-9b93-916dc48f20d7")
 	)
-	(label "CAN2_HI"
-		(at 267.97 80.01 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "b429db65-54a0-4eec-919a-f5c8f23c8d6e")
-	)
-	(label "CAN1_LO"
+	(label "CANL"
 		(at 267.97 87.63 180)
 		(fields_autoplaced yes)
 		(effects
@@ -6850,7 +6836,7 @@
 		)
 		(uuid "bf3b4a86-1ebf-4ee3-b3f6-54914e9a0a49")
 	)
-	(label "CAN1_HI"
+	(label "CANH"
 		(at 267.97 90.17 180)
 		(fields_autoplaced yes)
 		(effects
@@ -6893,6 +6879,17 @@
 			(justify right bottom)
 		)
 		(uuid "f774ed50-ba36-4866-a7e0-3731170a1ce9")
+	)
+	(label "PPS"
+		(at 242.57 48.26 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "faa0da75-390b-46de-a1c4-df70485a1b84")
 	)
 	(symbol
 		(lib_id "Device:R_US")
@@ -10571,72 +10568,6 @@
 			(project ""
 				(path "/d96f300b-87d4-4b9f-96ad-2ce544b71732"
 					(reference "#PWR012")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:+5V")
-		(at 266.7 30.48 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "ef2e68c4-de88-479d-9776-e06c45890187")
-		(property "Reference" "#PWR01"
-			(at 266.7 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "VBATT"
-			(at 266.7 25.4 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 266.7 30.48 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 266.7 30.48 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 266.7 30.48 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "5b288163-4313-4ff9-b488-58879dab9ac4")
-		)
-		(instances
-			(project "blaze_brain"
-				(path "/d96f300b-87d4-4b9f-96ad-2ce544b71732"
-					(reference "#PWR01")
 					(unit 1)
 				)
 			)

--- a/hardware/blaze_gps/blaze_gps.kicad_sch
+++ b/hardware/blaze_gps/blaze_gps.kicad_sch
@@ -1288,6 +1288,957 @@
 				)
 			)
 		)
+		(symbol "Connector_Generic:Conn_01x30"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 38.1 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x30"
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x30_1_1"
+				(rectangle
+					(start -1.27 -37.973)
+					(end 0 -38.227)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -35.433)
+					(end 0 -35.687)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -32.893)
+					(end 0 -33.147)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -30.353)
+					(end 0 -30.607)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -27.813)
+					(end 0 -28.067)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -25.273)
+					(end 0 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -22.733)
+					(end 0 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 20.447)
+					(end 0 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 22.987)
+					(end 0 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 25.527)
+					(end 0 25.273)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 28.067)
+					(end 0 27.813)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 30.607)
+					(end 0 30.353)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 33.147)
+					(end 0 32.893)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 35.687)
+					(end 0 35.433)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 36.83)
+					(end 1.27 -39.37)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 35.56 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 33.02 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -22.86 0)
+					(length 3.81)
+					(name "Pin_24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -25.4 0)
+					(length 3.81)
+					(name "Pin_25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -27.94 0)
+					(length 3.81)
+					(name "Pin_26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -30.48 0)
+					(length 3.81)
+					(name "Pin_27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -33.02 0)
+					(length 3.81)
+					(name "Pin_28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -35.56 0)
+					(length 3.81)
+					(name "Pin_29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 30.48 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -38.1 0)
+					(length 3.81)
+					(name "Pin_30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 27.94 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 25.4 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 22.86 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 20.32 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "Connector_Generic:Conn_02x05_Odd_Even"
 			(pin_names
 				(offset 1.016) hide)
@@ -5148,6 +6099,126 @@
 				)
 			)
 		)
+		(symbol "power:+5V"
+			(power)
+			(pin_numbers hide)
+			(pin_names
+				(offset 0) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "power:GND"
 			(power)
 			(pin_numbers hide)
@@ -5396,6 +6467,12 @@
 		(uuid "0f4a6311-5f8a-470f-970f-a0ea26751394")
 	)
 	(junction
+		(at 243.84 86.36)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2aaa4f9b-a17b-4656-90c4-f0f03bdaf5e1")
+	)
+	(junction
 		(at 251.46 147.32)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5456,6 +6533,18 @@
 		(uuid "54da7422-fcd2-43fe-8113-b94eda373a9b")
 	)
 	(junction
+		(at 238.76 104.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "577367a3-36f1-4748-bbe4-58197a6aa384")
+	)
+	(junction
+		(at 254 33.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5a0bf216-ce61-4012-bd55-66086b730372")
+	)
+	(junction
 		(at 113.03 125.73)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5498,6 +6587,18 @@
 		(uuid "7cf1a04c-8969-4d80-b6f7-798e20d03d90")
 	)
 	(junction
+		(at 243.84 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7d9699ae-6100-4c90-93b5-532e1fafcfb4")
+	)
+	(junction
+		(at 243.84 99.06)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7f71040e-208c-43b2-9325-9bcdef5d15fd")
+	)
+	(junction
 		(at 34.29 59.69)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5538,6 +6639,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "b1c6ef8f-a99a-4d71-807e-0cdd0027a019")
+	)
+	(junction
+		(at 243.84 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b5815b33-ed6b-47c0-a4e3-55c004d1e35c")
 	)
 	(junction
 		(at 138.43 133.35)
@@ -5594,12 +6701,28 @@
 		(uuid "f0435e6e-d02c-4789-89e0-364235e67865")
 	)
 	(no_connect
+		(at 255.27 50.8)
+		(uuid "07a05595-7158-47e9-b4de-fbf427fcb32d")
+	)
+	(no_connect
 		(at 96.52 154.94)
 		(uuid "0b25d179-91a9-4684-a1b1-2482f0da51fb")
 	)
 	(no_connect
 		(at 73.66 39.37)
 		(uuid "0bc1cc78-ac0a-4248-a51d-5ef3a1a80041")
+	)
+	(no_connect
+		(at 255.27 81.28)
+		(uuid "19c2d3d4-173c-4c51-aff4-d6d2e57be039")
+	)
+	(no_connect
+		(at 255.27 78.74)
+		(uuid "1d210404-860c-4c81-bd96-aeecf4addecb")
+	)
+	(no_connect
+		(at 255.27 45.72)
+		(uuid "1de2b3f5-8a24-42e3-89ba-8a995e5290d6")
 	)
 	(no_connect
 		(at 55.88 142.24)
@@ -5620,6 +6743,14 @@
 	(no_connect
 		(at 55.88 149.86)
 		(uuid "38db3a63-e7b8-4a41-93a8-c565778164d5")
+	)
+	(no_connect
+		(at 255.27 96.52)
+		(uuid "4f2ca4b1-f46e-4440-8ed0-62a643721e9c")
+	)
+	(no_connect
+		(at 255.27 71.12)
+		(uuid "544ed11f-a763-4434-8174-7590ee6a4198")
 	)
 	(no_connect
 		(at 55.88 64.77)
@@ -5644,6 +6775,10 @@
 	(no_connect
 		(at 55.88 82.55)
 		(uuid "95f62147-41b5-4b1d-9d1e-e7bafc4300c9")
+	)
+	(no_connect
+		(at 255.27 93.98)
+		(uuid "a043c0e5-edb9-40c3-82d5-1101a7543ccb")
 	)
 	(no_connect
 		(at 91.44 52.07)
@@ -5674,8 +6809,20 @@
 		(uuid "c7d12faf-a18d-4d8c-9026-8dcfe48a6e2b")
 	)
 	(no_connect
+		(at 255.27 48.26)
+		(uuid "cf09e875-b7b9-4da7-abbd-d2464a1f3c33")
+	)
+	(no_connect
+		(at 255.27 43.18)
+		(uuid "cf15d99b-090f-4580-b4bb-8de1b0887005")
+	)
+	(no_connect
 		(at 55.88 59.69)
 		(uuid "d13cf3ee-033a-41de-b591-cc2e5c9a525f")
+	)
+	(no_connect
+		(at 255.27 53.34)
+		(uuid "d3cc9bca-e938-4e0e-aba5-4c0dfcd7483b")
 	)
 	(no_connect
 		(at 96.52 157.48)
@@ -5688,6 +6835,14 @@
 	(no_connect
 		(at 55.88 62.23)
 		(uuid "da38c485-3583-4d0f-b8ac-b2b9a19e5cd8")
+	)
+	(no_connect
+		(at 255.27 55.88)
+		(uuid "e0f452af-9eaf-4db2-8ad4-81684f44e01f")
+	)
+	(no_connect
+		(at 255.27 73.66)
+		(uuid "f4f69d1e-db1d-47f3-ad0c-4efc794f5020")
 	)
 	(no_connect
 		(at 55.88 165.1)
@@ -5705,6 +6860,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 66.04) (xy 243.84 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "01eb770c-3fee-4a06-b2c8-87ef0c7bd12e")
+	)
+	(wire
+		(pts
 			(xy 261.62 149.86) (xy 262.89 149.86)
 		)
 		(stroke
@@ -5712,6 +6877,16 @@
 			(type default)
 		)
 		(uuid "03009498-8ee5-4883-b9b8-1731a47c0d3e")
+	)
+	(wire
+		(pts
+			(xy 243.84 99.06) (xy 243.84 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06598767-d54e-4ca5-a379-21edf5be0cbf")
 	)
 	(wire
 		(pts
@@ -5805,6 +6980,16 @@
 	)
 	(wire
 		(pts
+			(xy 238.76 106.68) (xy 255.27 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "19b1ecbb-2a81-4835-8e62-37cdf22ceb67")
+	)
+	(wire
+		(pts
 			(xy 248.92 147.32) (xy 251.46 147.32)
 		)
 		(stroke
@@ -5825,6 +7010,26 @@
 	)
 	(wire
 		(pts
+			(xy 254 33.02) (xy 254 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1fda7289-ed87-4b24-89e9-649a3b01c59e")
+	)
+	(wire
+		(pts
+			(xy 238.76 104.14) (xy 255.27 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23234309-0efd-4bed-aca8-ec4f1ae330af")
+	)
+	(wire
+		(pts
 			(xy 49.53 132.08) (xy 55.88 132.08)
 		)
 		(stroke
@@ -5832,6 +7037,16 @@
 			(type default)
 		)
 		(uuid "242b8065-331c-45ce-8fd0-95e942df224c")
+	)
+	(wire
+		(pts
+			(xy 243.84 101.6) (xy 255.27 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "261766b4-5eb8-4bbf-9e26-83b95a557162")
 	)
 	(wire
 		(pts
@@ -5895,6 +7110,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 83.82) (xy 243.84 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30a107d5-ed27-4475-8025-d02d4bd2e2f3")
+	)
+	(wire
+		(pts
 			(xy 55.88 184.15) (xy 76.2 184.15)
 		)
 		(stroke
@@ -5935,6 +7160,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 41.91) (xy 243.84 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35d96fa1-dafc-45ba-a41c-66c7e06d736f")
+	)
+	(wire
+		(pts
 			(xy 210.82 146.05) (xy 219.71 146.05)
 		)
 		(stroke
@@ -5962,6 +7197,16 @@
 			(type default)
 		)
 		(uuid "3a1cf17d-8b6d-4a1f-abfb-0b65a3ee88b1")
+	)
+	(wire
+		(pts
+			(xy 250.19 91.44) (xy 255.27 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b7a1680-bf5d-4624-9997-383313435bf6")
 	)
 	(wire
 		(pts
@@ -6035,6 +7280,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 99.06) (xy 255.27 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e927242-b166-47fa-9fd6-70ea8fe3079b")
+	)
+	(wire
+		(pts
 			(xy 34.29 63.5) (xy 33.02 63.5)
 		)
 		(stroke
@@ -6065,6 +7320,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 66.04) (xy 255.27 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55d01227-6dc2-4e60-babb-638e41075173")
+	)
+	(wire
+		(pts
 			(xy 125.73 62.23) (xy 132.08 62.23)
 		)
 		(stroke
@@ -6085,6 +7350,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 68.58) (xy 255.27 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b2d627c-a139-412c-b19a-1737f2c51f28")
+	)
+	(wire
+		(pts
 			(xy 34.29 63.5) (xy 34.29 64.77)
 		)
 		(stroke
@@ -6095,6 +7370,16 @@
 	)
 	(wire
 		(pts
+			(xy 250.19 88.9) (xy 255.27 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5bd65000-ae5c-43d1-9532-3570f50ae1ce")
+	)
+	(wire
+		(pts
 			(xy 210.82 151.13) (xy 215.9 151.13)
 		)
 		(stroke
@@ -6102,6 +7387,16 @@
 			(type default)
 		)
 		(uuid "5bdebced-c4ec-4420-badb-dae377b3feac")
+	)
+	(wire
+		(pts
+			(xy 245.11 58.42) (xy 255.27 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c7fd729-72dc-4083-b83b-4f11540a5365")
 	)
 	(wire
 		(pts
@@ -6175,6 +7470,16 @@
 	)
 	(wire
 		(pts
+			(xy 240.03 58.42) (xy 240.03 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b2aeb15-cc8d-4d09-90eb-163e84b012f5")
+	)
+	(wire
+		(pts
 			(xy 233.68 149.86) (xy 233.68 148.59)
 		)
 		(stroke
@@ -6215,6 +7520,16 @@
 	)
 	(wire
 		(pts
+			(xy 238.76 104.14) (xy 238.76 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "701446fa-0708-41ef-bbb5-73ad6da7cc7f")
+	)
+	(wire
+		(pts
 			(xy 91.44 77.47) (xy 95.25 77.47)
 		)
 		(stroke
@@ -6245,6 +7560,16 @@
 	)
 	(wire
 		(pts
+			(xy 251.46 76.2) (xy 255.27 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78be0424-69e0-47a9-b609-0bd69390c1c9")
+	)
+	(wire
+		(pts
 			(xy 50.8 157.48) (xy 55.88 157.48)
 		)
 		(stroke
@@ -6262,6 +7587,26 @@
 			(type default)
 		)
 		(uuid "79e00591-7b32-413b-9ee9-5e06ed2d9ba1")
+	)
+	(wire
+		(pts
+			(xy 254 33.02) (xy 255.27 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82fca65b-541d-4cb8-8a6c-7476fa7c7d8d")
+	)
+	(wire
+		(pts
+			(xy 254 35.56) (xy 255.27 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "834a9730-43eb-45cc-a139-98592d0a37db")
 	)
 	(wire
 		(pts
@@ -6302,6 +7647,16 @@
 			(type default)
 		)
 		(uuid "868cfff1-9f73-4e2a-b8cb-504653c26373")
+	)
+	(wire
+		(pts
+			(xy 243.84 40.64) (xy 255.27 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "898fa4a2-9cba-46ac-bf2b-b4ccd5973b77")
 	)
 	(wire
 		(pts
@@ -6452,6 +7807,26 @@
 			(type default)
 		)
 		(uuid "9e3c224e-9606-4c3c-b8d6-92506b7ac048")
+	)
+	(wire
+		(pts
+			(xy 243.84 68.58) (xy 243.84 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9fb24ad0-e977-4607-84dc-dd9661e8860e")
+	)
+	(wire
+		(pts
+			(xy 243.84 86.36) (xy 255.27 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a02b88b8-9ef7-4d88-9e0c-970f5933141f")
 	)
 	(wire
 		(pts
@@ -6675,6 +8050,16 @@
 	)
 	(wire
 		(pts
+			(xy 243.84 83.82) (xy 255.27 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "caa5edca-257b-4411-bd42-0c7726854c72")
+	)
+	(wire
+		(pts
 			(xy 116.84 62.23) (xy 116.84 64.77)
 		)
 		(stroke
@@ -6712,6 +8097,16 @@
 			(type default)
 		)
 		(uuid "d7a2e122-93c5-4441-9814-81a927dcd6a3")
+	)
+	(wire
+		(pts
+			(xy 243.84 86.36) (xy 243.84 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9c958c4-a7b1-4d53-b13d-962ddbc66dde")
 	)
 	(wire
 		(pts
@@ -6835,6 +8230,26 @@
 	)
 	(wire
 		(pts
+			(xy 240.03 60.96) (xy 255.27 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee16f3e4-9a4a-4d0d-b7b6-6fe7e0eb65ba")
+	)
+	(wire
+		(pts
+			(xy 255.27 38.1) (xy 243.84 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee2563aa-53bf-4b9c-b825-24ffed3e97b3")
+	)
+	(wire
+		(pts
 			(xy 71.12 34.29) (xy 71.12 39.37)
 		)
 		(stroke
@@ -6842,6 +8257,16 @@
 			(type default)
 		)
 		(uuid "eead6c08-68ee-4263-946e-7e1ae004a4f6")
+	)
+	(wire
+		(pts
+			(xy 238.76 99.06) (xy 238.76 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f016d009-33ca-4a37-a57c-37251fe2e87f")
 	)
 	(wire
 		(pts
@@ -6875,6 +8300,16 @@
 	)
 	(wire
 		(pts
+			(xy 251.46 63.5) (xy 255.27 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4dc414b-89d4-4061-ab72-c047f7c532a0")
+	)
+	(wire
+		(pts
 			(xy 262.89 142.24) (xy 269.24 142.24)
 		)
 		(stroke
@@ -6882,6 +8317,16 @@
 			(type default)
 		)
 		(uuid "f6249d1d-f66f-490e-8c43-8fc730462d58")
+	)
+	(wire
+		(pts
+			(xy 243.84 38.1) (xy 243.84 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f70d0ff4-c54b-4268-9b26-2010af7f2fcf")
 	)
 	(wire
 		(pts
@@ -6915,6 +8360,16 @@
 	)
 	(wire
 		(pts
+			(xy 254 31.75) (xy 254 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe37c158-c6eb-4b1d-9501-aedd9a31b806")
+	)
+	(wire
+		(pts
 			(xy 262.89 152.4) (xy 269.24 152.4)
 		)
 		(stroke
@@ -6922,6 +8377,28 @@
 			(type default)
 		)
 		(uuid "ff23e590-1140-46d9-bc48-9401d92aed85")
+	)
+	(label "PPS"
+		(at 255.27 63.5 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "006c1598-eae7-485d-b1f5-69ba428fd894")
+	)
+	(label "CANH"
+		(at 255.27 91.44 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "00fcc740-16bf-4892-ac83-bdbe424be06a")
 	)
 	(label "TMS{slash}SWDAT"
 		(at 96.52 162.56 0)
@@ -6933,17 +8410,6 @@
 			(justify left bottom)
 		)
 		(uuid "0457202b-61e0-43ef-855a-b919d0ec7f79")
-	)
-	(label "PPS"
-		(at 265.43 124.46 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "08a6900f-e2d0-4ae8-84ca-9c7c6658e618")
 	)
 	(label "GOFENCE_STAT"
 		(at 96.52 142.24 0)
@@ -7142,6 +8608,17 @@
 			(justify right bottom)
 		)
 		(uuid "7a064df7-23e9-4950-b8da-4642f4a88884")
+	)
+	(label "CANL"
+		(at 255.27 88.9 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7eafea52-e0b4-48b7-b771-4e4915751fa7")
 	)
 	(label "TDO"
 		(at 55.88 154.94 180)
@@ -8739,6 +10216,71 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 243.84 99.06 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2fc442bf-aa38-42a8-b07a-e2e696e073c8")
+		(property "Reference" "#PWR040"
+			(at 243.84 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 243.84 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 243.84 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 243.84 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 243.84 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a263b496-463a-41b1-9aca-fff6138429c6")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR040")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Connector_Generic:Conn_02x05_Odd_Even")
 		(at 123.19 156.21 0)
 		(unit 1)
@@ -9243,6 +10785,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 240.03 58.42 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3c845426-a6c9-4e9a-acb8-7dd75bb27b80")
+		(property "Reference" "#PWR034"
+			(at 240.03 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 240.03 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 240.03 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 240.03 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 240.03 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "861a7b98-8455-4edb-b84f-c1ee9b41433a")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR034")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
 		(at 73.66 95.25 0)
 		(unit 1)
@@ -9371,6 +10979,72 @@
 			(project "blaze_gps"
 				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
 					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 254 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40f44284-85c4-46a4-9a2a-114c1871d851")
+		(property "Reference" "#PWR032"
+			(at 254 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VBATT"
+			(at 254 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 254 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 254 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 254 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7ec12cb1-747b-46ad-ae05-6626f3a1273f")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR032")
 					(unit 1)
 				)
 			)
@@ -9845,6 +11519,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 238.76 99.06 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "818c9c85-b8ab-48d9-8e65-0b5bd3f88a9e")
+		(property "Reference" "#PWR039"
+			(at 238.76 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 238.76 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 238.76 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 238.76 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 238.76 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "010081d8-7c7f-46cc-a9fd-63cf15e58e42")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR039")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:VCC")
 		(at 78.74 39.37 0)
 		(unit 1)
@@ -9905,6 +11645,72 @@
 			(project "blaze_gps"
 				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
 					(reference "#PWR026")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 245.11 58.42 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8f82467f-9c87-4599-ae2e-3b3969f0b11e")
+		(property "Reference" "#PWR035"
+			(at 245.11 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 245.11 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 245.11 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 245.11 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 245.11 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bbd2bc45-ae0a-41a7-b3f6-61eea8f45234")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR035")
 					(unit 1)
 				)
 			)
@@ -10172,6 +11978,137 @@
 			(project "blaze_gps"
 				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
 					(reference "#PWR031")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 243.84 69.85 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9bee58c9-f8c4-4603-bf5f-bee0ca722d4a")
+		(property "Reference" "#PWR036"
+			(at 243.84 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 243.84 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 243.84 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 243.84 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 243.84 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be4efecc-9d3d-4fe2-9a24-fbe53e1b0109")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR036")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 243.84 87.63 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a1ef1b0f-0170-498a-b064-698fbe88ae9d")
+		(property "Reference" "#PWR038"
+			(at 243.84 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 243.84 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 243.84 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 243.84 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 243.84 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "32d3a13f-e24a-4c0b-983c-749495385673")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR038")
 					(unit 1)
 				)
 			)
@@ -10989,6 +12926,138 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 251.46 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cb741481-292d-49d2-9ae4-68430ad30cd1")
+		(property "Reference" "#PWR037"
+			(at 251.46 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 251.46 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 251.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 251.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 251.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "564ada2a-027f-4094-a6d0-08b5fd459547")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR037")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 243.84 41.91 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d0218f0b-175e-41ff-873a-e64290361bec")
+		(property "Reference" "#PWR033"
+			(at 243.84 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 243.84 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 243.84 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 243.84 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 243.84 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2c264b40-7646-4450-acea-07db12ac58c4")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "#PWR033")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:+3V3")
 		(at 223.52 156.21 0)
 		(unit 1)
@@ -11556,6 +13625,159 @@
 			(project "blaze_gps"
 				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
 					(reference "U3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x30")
+		(at 260.35 68.58 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e3ce795d-b999-420e-bc93-ba233c5b35a3")
+		(property "Reference" "J2"
+			(at 262.89 68.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x30"
+			(at 264.16 81.788 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 260.35 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 260.35 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 260.35 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "5"
+			(uuid "30239118-0697-422a-b0b5-4fd98f52ee07")
+		)
+		(pin "20"
+			(uuid "bf9c51e8-d3e2-4e2f-9ad7-cd65e4fdf0ff")
+		)
+		(pin "24"
+			(uuid "b697e0f5-0e65-4e19-8f87-462dc4c3ab1a")
+		)
+		(pin "7"
+			(uuid "faecbd16-30fc-4ede-befe-d9a5e58a3f66")
+		)
+		(pin "4"
+			(uuid "c928a83b-59f4-4936-ba16-e19ebea80bc8")
+		)
+		(pin "3"
+			(uuid "36418bbb-b591-464e-8ba3-b685fb30b317")
+		)
+		(pin "22"
+			(uuid "aed33f47-b084-4b71-9f16-35e4ab3e71b6")
+		)
+		(pin "16"
+			(uuid "5490cd01-0c70-4d13-8b4a-27ba2a40ddc5")
+		)
+		(pin "23"
+			(uuid "caed7507-e332-4f1f-8573-ee1e700ad26e")
+		)
+		(pin "21"
+			(uuid "d2c37814-097f-4d0d-9071-b3f70805c4e5")
+		)
+		(pin "2"
+			(uuid "fe25ba06-a94f-4f1d-a573-f94d06aa8806")
+		)
+		(pin "29"
+			(uuid "506758be-7f46-4189-b815-9913e2923165")
+		)
+		(pin "15"
+			(uuid "c34f283c-4406-4908-9288-3752ef9d75b2")
+		)
+		(pin "25"
+			(uuid "40a5b234-61a2-4e59-b913-639cdac2deb2")
+		)
+		(pin "6"
+			(uuid "6aba05dd-d02f-4b3c-b726-ec1acb9c58a8")
+		)
+		(pin "1"
+			(uuid "229ac022-31b8-4b63-a60f-b9f291f96e04")
+		)
+		(pin "12"
+			(uuid "0ff991ef-190d-4cda-83df-3b51921524df")
+		)
+		(pin "11"
+			(uuid "9f810700-fbd3-4b00-92ff-583dbce9c75c")
+		)
+		(pin "8"
+			(uuid "9fdd436b-7d76-4b83-806e-e1ebcf34d8ac")
+		)
+		(pin "10"
+			(uuid "f9f73018-31c6-4502-b8f5-3ac5a51c1de5")
+		)
+		(pin "13"
+			(uuid "4e24fe97-d2bd-46b9-be88-3c30fb71f087")
+		)
+		(pin "17"
+			(uuid "4690adbe-3999-4678-9649-d7fb5bf68e93")
+		)
+		(pin "26"
+			(uuid "8adad776-ad50-457a-af31-b709bd318099")
+		)
+		(pin "28"
+			(uuid "97629854-1aa1-4580-9fca-dbd6aefdb9bd")
+		)
+		(pin "18"
+			(uuid "2ee64642-2300-4562-97ae-27a06d07479f")
+		)
+		(pin "19"
+			(uuid "547b3de1-830d-4f67-bb57-cc4017b013c9")
+		)
+		(pin "9"
+			(uuid "bf1445e4-7569-47c9-9809-d2fc10b25f92")
+		)
+		(pin "14"
+			(uuid "c875bde9-3ac3-453d-9691-55b5a73db565")
+		)
+		(pin "27"
+			(uuid "06682517-cce1-4fd6-b620-908e1f6ca697")
+		)
+		(pin "30"
+			(uuid "05b83dc8-ca4e-4063-ac00-e646205885d2")
+		)
+		(instances
+			(project "blaze_gps"
+				(path "/86bdf6fb-b933-4971-a096-dd7ab50bb164"
+					(reference "J2")
 					(unit 1)
 				)
 			)

--- a/hardware/blaze_io/blaze_io.kicad_sch
+++ b/hardware/blaze_io/blaze_io.kicad_sch
@@ -1585,6 +1585,957 @@
 				)
 			)
 		)
+		(symbol "Connector_Generic:Conn_01x30"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 38.1 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x30"
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x30_1_1"
+				(rectangle
+					(start -1.27 -37.973)
+					(end 0 -38.227)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -35.433)
+					(end 0 -35.687)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -32.893)
+					(end 0 -33.147)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -30.353)
+					(end 0 -30.607)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -27.813)
+					(end 0 -28.067)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -25.273)
+					(end 0 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -22.733)
+					(end 0 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 20.447)
+					(end 0 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 22.987)
+					(end 0 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 25.527)
+					(end 0 25.273)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 28.067)
+					(end 0 27.813)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 30.607)
+					(end 0 30.353)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 33.147)
+					(end 0 32.893)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 35.687)
+					(end 0 35.433)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 36.83)
+					(end 1.27 -39.37)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 35.56 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 33.02 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -22.86 0)
+					(length 3.81)
+					(name "Pin_24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -25.4 0)
+					(length 3.81)
+					(name "Pin_25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -27.94 0)
+					(length 3.81)
+					(name "Pin_26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -30.48 0)
+					(length 3.81)
+					(name "Pin_27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -33.02 0)
+					(length 3.81)
+					(name "Pin_28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -35.56 0)
+					(length 3.81)
+					(name "Pin_29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 30.48 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -38.1 0)
+					(length 3.81)
+					(name "Pin_30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 27.94 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 25.4 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 22.86 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 20.32 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "Connector_Generic:Conn_02x05_Odd_Even"
 			(pin_names
 				(offset 1.016) hide)
@@ -5388,6 +6339,12 @@
 		(uuid "10cfcb82-fd3c-4664-9913-e57805b3a450")
 	)
 	(junction
+		(at 257.81 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "147c6191-8ab4-4206-b56b-53296440c6c3")
+	)
+	(junction
 		(at 158.75 68.58)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5442,10 +6399,22 @@
 		(uuid "45a84433-5d4b-4c3e-93ac-79bf5742c9d7")
 	)
 	(junction
+		(at 257.81 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4618533f-9801-461c-ae63-c6327ed02e0a")
+	)
+	(junction
 		(at 85.09 176.53)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "497e8c0b-2957-4e10-b948-9495924da41d")
+	)
+	(junction
+		(at 257.81 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c071e9c-44d6-4955-825d-338e079ddf1b")
 	)
 	(junction
 		(at 133.35 40.64)
@@ -5458,6 +6427,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "585e9fbc-700b-46ff-a222-94efe4444eed")
+	)
+	(junction
+		(at 252.73 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "600c64e9-62c4-452a-a31b-fbaa79dbf15f")
 	)
 	(junction
 		(at 133.35 81.28)
@@ -5496,10 +6471,22 @@
 		(uuid "75d82146-630f-4e9b-b8b2-abb8e34e489b")
 	)
 	(junction
+		(at 257.81 43.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "763039bd-1dc7-4197-ba3b-63a30558ed71")
+	)
+	(junction
 		(at 260.35 139.7)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "7baa5c23-344a-4c99-8da4-43e20e2f9d67")
+	)
+	(junction
+		(at 267.97 35.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bba6f88-4107-49df-aa48-ea35e4cb3226")
 	)
 	(junction
 		(at 140.97 40.64)
@@ -5648,6 +6635,10 @@
 		(uuid "2909fdc3-fac7-4fed-a8ad-065d063935a0")
 	)
 	(no_connect
+		(at 269.24 73.66)
+		(uuid "2a22e10d-2a21-4d5b-ba58-8a81f2d1f563")
+	)
+	(no_connect
 		(at 64.77 157.48)
 		(uuid "30997c76-74bc-4c61-8f98-e9c944639d62")
 	)
@@ -5656,16 +6647,44 @@
 		(uuid "379d0a46-c031-4694-8fba-0bc6c51b680f")
 	)
 	(no_connect
+		(at 269.24 76.2)
+		(uuid "4a6fe6f3-61f6-4e03-860f-86749ed61c92")
+	)
+	(no_connect
+		(at 269.24 99.06)
+		(uuid "4c02e436-b476-4628-8123-eeecb326b2d8")
+	)
+	(no_connect
 		(at 64.77 134.62)
 		(uuid "5a0c7729-509a-4883-b1d2-ceb2f04c104c")
 	)
 	(no_connect
-		(at 64.77 162.56)
-		(uuid "97622540-ece2-4f18-83e1-4dc23a2cf160")
+		(at 269.24 96.52)
+		(uuid "a43fc156-9cbb-41cc-9618-fe105b30270f")
+	)
+	(no_connect
+		(at 269.24 50.8)
+		(uuid "ae38c39a-7a5b-46d4-971e-7ee3eda9388f")
+	)
+	(no_connect
+		(at 269.24 58.42)
+		(uuid "bc51f39c-3948-4e8d-9622-30ced657859b")
+	)
+	(no_connect
+		(at 269.24 83.82)
+		(uuid "c020474c-cc95-476d-886b-9215efcffb40")
+	)
+	(no_connect
+		(at 269.24 81.28)
+		(uuid "ddff5844-99f9-48eb-913a-b17ed79d5d75")
 	)
 	(no_connect
 		(at 64.77 144.78)
 		(uuid "e64b4a72-290e-400d-bbf2-b7ff8417f906")
+	)
+	(no_connect
+		(at 269.24 55.88)
+		(uuid "e9ce7059-54cc-4e12-b21a-0cfad97815bf")
 	)
 	(wire
 		(pts
@@ -5899,6 +6918,16 @@
 	)
 	(wire
 		(pts
+			(xy 252.73 101.6) (xy 252.73 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "258f42a1-f24d-4b5d-9e14-624e87020780")
+	)
+	(wire
+		(pts
 			(xy 35.56 134.62) (xy 36.83 134.62)
 		)
 		(stroke
@@ -5979,6 +7008,16 @@
 	)
 	(wire
 		(pts
+			(xy 267.97 35.56) (xy 267.97 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38d47b33-36f4-4999-8b1d-ae7617152bd1")
+	)
+	(wire
+		(pts
 			(xy 134.62 125.73) (xy 140.97 125.73)
 		)
 		(stroke
@@ -5996,6 +7035,26 @@
 			(type default)
 		)
 		(uuid "3a093ffd-e66b-4957-b2fb-9ce903d64ff7")
+	)
+	(wire
+		(pts
+			(xy 257.81 88.9) (xy 257.81 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a613d2c-8965-4eb2-bb5a-d22ed79b8253")
+	)
+	(wire
+		(pts
+			(xy 267.97 34.29) (xy 267.97 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b0a2abb-1ae3-4cf0-8596-6bd691902592")
 	)
 	(wire
 		(pts
@@ -6029,7 +7088,7 @@
 	)
 	(wire
 		(pts
-			(xy 246.38 50.8) (xy 259.08 50.8)
+			(xy 210.82 104.14) (xy 223.52 104.14)
 		)
 		(stroke
 			(width 0)
@@ -6059,13 +7118,33 @@
 	)
 	(wire
 		(pts
-			(xy 215.9 53.34) (xy 231.14 53.34)
+			(xy 180.34 106.68) (xy 195.58 106.68)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "4a5d325c-a0e7-42dd-a671-fb6c38137e00")
+	)
+	(wire
+		(pts
+			(xy 264.16 93.98) (xy 269.24 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4b3c43b2-f0b8-4ae4-8c61-ce4f4e318210")
+	)
+	(wire
+		(pts
+			(xy 264.16 91.44) (xy 269.24 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4beb0633-4694-48c1-969a-fd60458fcf7a")
 	)
 	(wire
 		(pts
@@ -6106,6 +7185,16 @@
 			(type default)
 		)
 		(uuid "50809e19-2b86-4e2b-9e48-4429845ec55e")
+	)
+	(wire
+		(pts
+			(xy 259.08 60.96) (xy 269.24 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50e806f7-e7c9-45b0-9842-a28c96fc4fca")
 	)
 	(wire
 		(pts
@@ -6159,7 +7248,17 @@
 	)
 	(wire
 		(pts
-			(xy 215.9 38.1) (xy 231.14 38.1)
+			(xy 257.81 101.6) (xy 269.24 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "56175f53-8df1-4d38-86b0-70184d728313")
+	)
+	(wire
+		(pts
+			(xy 180.34 91.44) (xy 195.58 91.44)
 		)
 		(stroke
 			(width 0)
@@ -6176,6 +7275,16 @@
 			(type default)
 		)
 		(uuid "573f0c97-ad3e-4c83-8248-31858ef87cfd")
+	)
+	(wire
+		(pts
+			(xy 257.81 86.36) (xy 257.81 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57edfacd-1c2e-4c5a-a8d5-b770afa3c1d7")
 	)
 	(wire
 		(pts
@@ -6249,6 +7358,16 @@
 	)
 	(wire
 		(pts
+			(xy 252.73 106.68) (xy 269.24 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ba9f732-440e-4dd7-bf35-2fa704f75ad0")
+	)
+	(wire
+		(pts
 			(xy 181.61 40.64) (xy 191.77 40.64)
 		)
 		(stroke
@@ -6269,7 +7388,17 @@
 	)
 	(wire
 		(pts
-			(xy 218.44 35.56) (xy 231.14 35.56)
+			(xy 257.81 88.9) (xy 269.24 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f9ccb22-42c5-4424-b8f9-b085483fc353")
+	)
+	(wire
+		(pts
+			(xy 182.88 88.9) (xy 195.58 88.9)
 		)
 		(stroke
 			(width 0)
@@ -6316,6 +7445,16 @@
 			(type default)
 		)
 		(uuid "69af3594-5fed-412c-9aad-f162580dbeef")
+	)
+	(wire
+		(pts
+			(xy 257.81 40.64) (xy 257.81 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6aafdcf4-fa8e-4fc7-aae3-595acff7dd5d")
 	)
 	(wire
 		(pts
@@ -6389,6 +7528,26 @@
 	)
 	(wire
 		(pts
+			(xy 267.97 38.1) (xy 269.24 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "797c3a34-c96f-4982-84ab-0ed29c3580f9")
+	)
+	(wire
+		(pts
+			(xy 257.81 101.6) (xy 257.81 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a486aab-f04f-4990-92f5-189158174067")
+	)
+	(wire
+		(pts
 			(xy 40.64 43.18) (xy 45.72 43.18)
 		)
 		(stroke
@@ -6426,6 +7585,16 @@
 			(type default)
 		)
 		(uuid "7be6ffd8-46fa-49e2-9b16-ac04a636da51")
+	)
+	(wire
+		(pts
+			(xy 257.81 86.36) (xy 269.24 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7ccde8ba-336b-4124-adf9-531b378e5fd0")
 	)
 	(wire
 		(pts
@@ -6499,6 +7668,16 @@
 	)
 	(wire
 		(pts
+			(xy 267.97 35.56) (xy 269.24 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "897ca023-5a61-481c-a36a-ce239889e09e")
+	)
+	(wire
+		(pts
 			(xy 158.75 68.58) (xy 171.45 68.58)
 		)
 		(stroke
@@ -6529,7 +7708,7 @@
 	)
 	(wire
 		(pts
-			(xy 243.84 53.34) (xy 259.08 53.34)
+			(xy 208.28 106.68) (xy 223.52 106.68)
 		)
 		(stroke
 			(width 0)
@@ -6539,7 +7718,7 @@
 	)
 	(wire
 		(pts
-			(xy 246.38 35.56) (xy 259.08 35.56)
+			(xy 210.82 88.9) (xy 223.52 88.9)
 		)
 		(stroke
 			(width 0)
@@ -6586,6 +7765,26 @@
 			(type default)
 		)
 		(uuid "9910c0c2-db2b-4615-8937-894bce1fa2ee")
+	)
+	(wire
+		(pts
+			(xy 60.96 162.56) (xy 64.77 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9975cad4-8182-49ea-832f-3e2a73f36190")
+	)
+	(wire
+		(pts
+			(xy 257.81 71.12) (xy 257.81 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d0ce7ee-3018-4c77-87db-a6fdb4c25db3")
 	)
 	(wire
 		(pts
@@ -6739,6 +7938,16 @@
 	)
 	(wire
 		(pts
+			(xy 257.81 104.14) (xy 269.24 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aed841c0-e050-4edd-8d99-0b93f7ea1bc7")
+	)
+	(wire
+		(pts
 			(xy 139.7 146.05) (xy 151.13 146.05)
 		)
 		(stroke
@@ -6759,7 +7968,7 @@
 	)
 	(wire
 		(pts
-			(xy 243.84 38.1) (xy 259.08 38.1)
+			(xy 208.28 91.44) (xy 223.52 91.44)
 		)
 		(stroke
 			(width 0)
@@ -6829,6 +8038,26 @@
 	)
 	(wire
 		(pts
+			(xy 257.81 71.12) (xy 269.24 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bae8ba2a-93d1-4727-bd2d-48347ae02152")
+	)
+	(wire
+		(pts
+			(xy 254 63.5) (xy 269.24 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bcf08d42-c9eb-4515-b913-cf69eae72e99")
+	)
+	(wire
+		(pts
 			(xy 242.57 142.24) (xy 242.57 144.78)
 		)
 		(stroke
@@ -6839,7 +8068,17 @@
 	)
 	(wire
 		(pts
-			(xy 218.44 50.8) (xy 231.14 50.8)
+			(xy 252.73 109.22) (xy 269.24 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bdb8b166-23b6-4732-8953-f19127204a92")
+	)
+	(wire
+		(pts
+			(xy 182.88 104.14) (xy 195.58 104.14)
 		)
 		(stroke
 			(width 0)
@@ -6929,6 +8168,16 @@
 	)
 	(wire
 		(pts
+			(xy 257.81 44.45) (xy 257.81 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3b46a95-93ae-41f5-a1ac-174944c11c78")
+	)
+	(wire
+		(pts
 			(xy 271.78 142.24) (xy 271.78 144.78)
 		)
 		(stroke
@@ -6946,6 +8195,16 @@
 			(type default)
 		)
 		(uuid "d5b16315-83db-4bd5-8604-8db0af02c879")
+	)
+	(wire
+		(pts
+			(xy 257.81 68.58) (xy 269.24 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d5fcdd10-760f-4a90-afe5-2b8764a2229b")
 	)
 	(wire
 		(pts
@@ -6986,6 +8245,16 @@
 			(type default)
 		)
 		(uuid "d7fe98cd-62df-4b87-a277-7f355427f269")
+	)
+	(wire
+		(pts
+			(xy 265.43 78.74) (xy 269.24 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8629b2c-d252-4a18-a0e8-cbdabe675460")
 	)
 	(wire
 		(pts
@@ -7059,6 +8328,16 @@
 	)
 	(wire
 		(pts
+			(xy 269.24 40.64) (xy 257.81 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6eb254f-a863-4fb1-bcd1-12ccdd8dcf77")
+	)
+	(wire
+		(pts
 			(xy 180.34 144.78) (xy 185.42 144.78)
 		)
 		(stroke
@@ -7069,6 +8348,16 @@
 	)
 	(wire
 		(pts
+			(xy 265.43 53.34) (xy 269.24 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e86915e1-c0db-4a5e-ace3-747b985efbce")
+	)
+	(wire
+		(pts
 			(xy 22.86 64.77) (xy 22.86 73.66)
 		)
 		(stroke
@@ -7076,6 +8365,16 @@
 			(type default)
 		)
 		(uuid "eaa3f6be-1a3d-4eb8-b432-61856d2ec63e")
+	)
+	(wire
+		(pts
+			(xy 252.73 106.68) (xy 252.73 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eabc42ec-8730-411c-b4e3-b5666bea5aca")
 	)
 	(wire
 		(pts
@@ -7099,6 +8398,16 @@
 	)
 	(wire
 		(pts
+			(xy 254 60.96) (xy 254 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f179f111-df79-4381-9aa2-4f930dc0554a")
+	)
+	(wire
+		(pts
 			(xy 139.7 143.51) (xy 151.13 143.51)
 		)
 		(stroke
@@ -7109,6 +8418,26 @@
 	)
 	(wire
 		(pts
+			(xy 265.43 66.04) (xy 269.24 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5e72238-1d22-49f8-a104-38659e965fb9")
+	)
+	(wire
+		(pts
+			(xy 257.81 43.18) (xy 269.24 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f73f5f9c-1737-4754-8830-0fc6785226b3")
+	)
+	(wire
+		(pts
 			(xy 35.56 138.43) (xy 36.83 138.43)
 		)
 		(stroke
@@ -7116,6 +8445,16 @@
 			(type default)
 		)
 		(uuid "f825dba1-79ca-470b-8f57-5b881e4205e8")
+	)
+	(wire
+		(pts
+			(xy 257.81 68.58) (xy 257.81 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8a8b970-d84e-43f4-bdec-5731378e61f9")
 	)
 	(wire
 		(pts
@@ -7327,6 +8666,28 @@
 		)
 		(uuid "31df050c-f2ae-46c7-ae9d-c92c8488f166")
 	)
+	(label "CANL"
+		(at 269.24 91.44 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "377c5f53-233a-4b31-a700-bd7c72c9ee5a")
+	)
+	(label "PPS"
+		(at 64.77 162.56 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "39c2189f-dac0-4597-8e63-db9665ae3c30")
+	)
 	(label "FET_A"
 		(at 66.04 40.64 180)
 		(fields_autoplaced yes)
@@ -7339,7 +8700,7 @@
 		(uuid "3dc97796-05e4-4b70-a3ed-28eaa7131960")
 	)
 	(label "SERVO_SIG_4"
-		(at 259.08 50.8 180)
+		(at 223.52 104.14 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -7403,6 +8764,17 @@
 			(justify right bottom)
 		)
 		(uuid "56cedbb6-c31d-43bf-ad68-86b46bea4ae9")
+	)
+	(label "PPS"
+		(at 269.24 66.04 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "5e4c0e20-a901-4e32-add5-a92c9a20ca16")
 	)
 	(label "TDI"
 		(at 105.41 160.02 0)
@@ -7469,6 +8841,17 @@
 			(justify left bottom)
 		)
 		(uuid "7374a750-ea5c-40ae-9d08-8d7add52e277")
+	)
+	(label "CANH"
+		(at 269.24 93.98 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "781015a6-04f2-4165-9ef0-3059a8262c33")
 	)
 	(label "TMS{slash}SWDAT"
 		(at 139.7 143.51 0)
@@ -7548,7 +8931,7 @@
 		(uuid "9674ae3a-938c-49f9-8de1-ac5800f880d7")
 	)
 	(label "SERVO_SIG_2"
-		(at 259.08 35.56 180)
+		(at 223.52 88.9 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -7568,6 +8951,17 @@
 			(justify left bottom)
 		)
 		(uuid "9dd87b1d-ad7b-4830-9e0f-67fa1d3f93ea")
+	)
+	(label "ARM"
+		(at 269.24 53.34 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a59e8ca8-65f0-4e02-9d78-5761ff313176")
 	)
 	(label "FET_C_OUT"
 		(at 73.66 68.58 0)
@@ -7790,7 +9184,7 @@
 		(uuid "e90d5e1c-9401-4c7a-b3a7-60534c2f3e12")
 	)
 	(label "SERVO_SIG_1"
-		(at 231.14 35.56 180)
+		(at 195.58 88.9 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -7845,7 +9239,7 @@
 		(uuid "f6a6c611-c886-4e13-89a8-d32f4bcdfc69")
 	)
 	(label "SERVO_SIG_3"
-		(at 231.14 50.8 180)
+		(at 195.58 104.14 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -7865,6 +9259,72 @@
 			(justify left bottom)
 		)
 		(uuid "fdf8b7c7-dc3f-4663-a1ec-2fc196c04a51")
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 257.81 72.39 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "02e634e2-716b-4078-b2ca-6793f6581fe6")
+		(property "Reference" "#PWR042"
+			(at 257.81 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 257.81 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 257.81 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 257.81 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 257.81 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "39fbd743-7d8f-4422-a15a-ee5b5a0c66c4")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR042")
+					(unit 1)
+				)
+			)
+		)
 	)
 	(symbol
 		(lib_id "Device:R_US")
@@ -7938,7 +9398,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 215.9 53.34 0)
+		(at 180.34 106.68 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7947,7 +9407,7 @@
 		(fields_autoplaced yes)
 		(uuid "039897c0-cee8-4ddf-b81a-3ad3eee0761a")
 		(property "Reference" "#PWR034"
-			(at 215.9 57.15 0)
+			(at 180.34 110.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7956,7 +9416,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 215.9 48.26 0)
+			(at 180.34 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7964,7 +9424,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 215.9 53.34 0)
+			(at 180.34 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7973,7 +9433,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 215.9 53.34 0)
+			(at 180.34 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7982,7 +9442,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 215.9 53.34 0)
+			(at 180.34 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8276,7 +9736,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 231.14 40.64 0)
+		(at 195.58 93.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8285,7 +9745,7 @@
 		(fields_autoplaced yes)
 		(uuid "1c377b43-829c-49be-85f3-10172e1a2194")
 		(property "Reference" "#PWR030"
-			(at 231.14 46.99 0)
+			(at 195.58 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8294,7 +9754,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 231.14 45.72 0)
+			(at 195.58 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8302,7 +9762,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 231.14 40.64 0)
+			(at 195.58 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8311,7 +9771,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 231.14 40.64 0)
+			(at 195.58 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8320,7 +9780,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 231.14 40.64 0)
+			(at 195.58 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9054,6 +10514,71 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 257.81 90.17 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2a63cd24-2075-44d5-873f-b022a51cb7ff")
+		(property "Reference" "#PWR044"
+			(at 257.81 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 257.81 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 257.81 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 257.81 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 257.81 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c29a3ad4-17e0-4d97-b959-171beb4af7e0")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR044")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
 		(at 133.35 85.09 0)
 		(mirror y)
@@ -9321,6 +10846,72 @@
 			(project "blaze_io"
 				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
 					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 265.43 78.74 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3b644b5f-24f6-4578-9234-318e1a01be2c")
+		(property "Reference" "#PWR043"
+			(at 265.43 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 265.43 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 265.43 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 265.43 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 265.43 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "17b8e5c6-de20-4e2c-8f8a-87fa6f2a6741")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR043")
 					(unit 1)
 				)
 			)
@@ -9705,7 +11296,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x03_Pin")
-		(at 236.22 38.1 0)
+		(at 200.66 91.44 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -9715,7 +11306,7 @@
 		(fields_autoplaced yes)
 		(uuid "4894bed9-fa91-4563-b512-dd9a1c315b2e")
 		(property "Reference" "J4"
-			(at 237.49 36.8299 0)
+			(at 201.93 90.1699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9724,7 +11315,7 @@
 			)
 		)
 		(property "Value" "Conn_01x03_Pin"
-			(at 237.49 39.3699 0)
+			(at 201.93 92.7099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9733,7 +11324,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 236.22 38.1 0)
+			(at 200.66 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9742,7 +11333,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 236.22 38.1 0)
+			(at 200.66 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9751,7 +11342,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x03, script generated"
-			(at 236.22 38.1 0)
+			(at 200.66 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9846,7 +11437,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x03_Pin")
-		(at 264.16 38.1 0)
+		(at 228.6 91.44 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -9856,7 +11447,7 @@
 		(fields_autoplaced yes)
 		(uuid "4b314969-a5f2-4bdd-b7df-92fe351ab6e7")
 		(property "Reference" "J5"
-			(at 265.43 36.8299 0)
+			(at 229.87 90.1699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9865,7 +11456,7 @@
 			)
 		)
 		(property "Value" "Conn_01x03_Pin"
-			(at 265.43 39.3699 0)
+			(at 229.87 92.7099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9874,7 +11465,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 264.16 38.1 0)
+			(at 228.6 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9883,7 +11474,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 264.16 38.1 0)
+			(at 228.6 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9892,7 +11483,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x03, script generated"
-			(at 264.16 38.1 0)
+			(at 228.6 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9913,6 +11504,72 @@
 			(project "blaze_io"
 				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
 					(reference "J5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 254 60.96 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4c578ab5-7d71-42fc-96be-7fa0f8a0d461")
+		(property "Reference" "#PWR040"
+			(at 254 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 254 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 254 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 254 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 254 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f4292ea-f9b2-4852-9b10-c8f7ffe92729")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR040")
 					(unit 1)
 				)
 			)
@@ -10093,7 +11750,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 259.08 55.88 0)
+		(at 223.52 109.22 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -10102,7 +11759,7 @@
 		(fields_autoplaced yes)
 		(uuid "4f6ca856-1ffd-4dd2-986d-cef6ded15364")
 		(property "Reference" "#PWR037"
-			(at 259.08 62.23 0)
+			(at 223.52 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10111,7 +11768,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 259.08 60.96 0)
+			(at 223.52 114.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10119,7 +11776,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 259.08 55.88 0)
+			(at 223.52 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10128,7 +11785,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 259.08 55.88 0)
+			(at 223.52 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10137,7 +11794,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 259.08 55.88 0)
+			(at 223.52 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10316,7 +11973,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 231.14 55.88 0)
+		(at 195.58 109.22 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -10325,7 +11982,7 @@
 		(fields_autoplaced yes)
 		(uuid "57563e06-51ec-44cb-9e8e-46f53e19a131")
 		(property "Reference" "#PWR036"
-			(at 231.14 62.23 0)
+			(at 195.58 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10334,7 +11991,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 231.14 60.96 0)
+			(at 195.58 114.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10342,7 +11999,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 231.14 55.88 0)
+			(at 195.58 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10351,7 +12008,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 231.14 55.88 0)
+			(at 195.58 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10360,7 +12017,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 231.14 55.88 0)
+			(at 195.58 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10581,7 +12238,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 243.84 38.1 0)
+		(at 208.28 91.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -10590,7 +12247,7 @@
 		(fields_autoplaced yes)
 		(uuid "6542db5a-30e0-4ddc-af7f-9c53bc1a0fde")
 		(property "Reference" "#PWR032"
-			(at 243.84 41.91 0)
+			(at 208.28 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10599,7 +12256,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 243.84 33.02 0)
+			(at 208.28 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10607,7 +12264,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 243.84 38.1 0)
+			(at 208.28 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10616,7 +12273,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 243.84 38.1 0)
+			(at 208.28 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10625,7 +12282,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 243.84 38.1 0)
+			(at 208.28 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10816,6 +12473,72 @@
 			(project "blaze_io"
 				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
 					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 252.73 101.6 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6f0bb8d3-f05f-490b-94ae-908fcbd6caab")
+		(property "Reference" "#PWR045"
+			(at 252.73 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 252.73 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 252.73 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 252.73 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 252.73 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7afd2210-18aa-40a2-84db-429ba16303b6")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR045")
 					(unit 1)
 				)
 			)
@@ -11431,7 +13154,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x03_Pin")
-		(at 264.16 53.34 0)
+		(at 228.6 106.68 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -11441,7 +13164,7 @@
 		(fields_autoplaced yes)
 		(uuid "898c9372-d25b-4ef0-aecd-245969fecca7")
 		(property "Reference" "J7"
-			(at 265.43 52.0699 0)
+			(at 229.87 105.4099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11450,7 +13173,7 @@
 			)
 		)
 		(property "Value" "Conn_01x03_Pin"
-			(at 265.43 54.6099 0)
+			(at 229.87 107.9499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11459,7 +13182,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 264.16 53.34 0)
+			(at 228.6 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11468,7 +13191,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 264.16 53.34 0)
+			(at 228.6 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11477,7 +13200,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x03, script generated"
-			(at 264.16 53.34 0)
+			(at 228.6 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11766,6 +13489,72 @@
 			(project "blaze_io"
 				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
 					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 259.08 60.96 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "94401447-895e-49fb-adee-c263da60aa84")
+		(property "Reference" "#PWR041"
+			(at 259.08 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 259.08 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 259.08 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 259.08 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 259.08 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "45530a93-2ae9-404d-b1ab-cc6051bc1b16")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR041")
 					(unit 1)
 				)
 			)
@@ -12362,7 +14151,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 259.08 40.64 0)
+		(at 223.52 93.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -12371,7 +14160,7 @@
 		(fields_autoplaced yes)
 		(uuid "a41d1b87-a690-45f6-a472-9bc020fc609b")
 		(property "Reference" "#PWR033"
-			(at 259.08 46.99 0)
+			(at 223.52 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12380,7 +14169,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 259.08 45.72 0)
+			(at 223.52 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12388,7 +14177,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 259.08 40.64 0)
+			(at 223.52 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12397,7 +14186,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 259.08 40.64 0)
+			(at 223.52 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12406,7 +14195,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 259.08 40.64 0)
+			(at 223.52 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12609,6 +14398,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 257.81 44.45 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b055a56e-4773-48e1-8721-2b4df391b101")
+		(property "Reference" "#PWR039"
+			(at 257.81 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 257.81 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 257.81 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 257.81 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 257.81 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f59cd188-77a9-452a-9fc7-9c0441a9a6d4")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR039")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
 		(at 66.04 77.47 0)
 		(mirror y)
@@ -12739,6 +14594,71 @@
 			(project "blaze_io"
 				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
 					(reference "#PWR029")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 257.81 101.6 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b9bd9943-3bdc-4bb7-8017-9f319b780dd6")
+		(property "Reference" "#PWR046"
+			(at 257.81 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 257.81 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 257.81 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 257.81 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 257.81 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "536f4ef4-dd08-40e0-b706-5419742e6f07")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR046")
 					(unit 1)
 				)
 			)
@@ -13267,7 +15187,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x03_Pin")
-		(at 236.22 53.34 0)
+		(at 200.66 106.68 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -13277,7 +15197,7 @@
 		(fields_autoplaced yes)
 		(uuid "c95b7a5a-f454-4654-ab31-e0026f6f1c94")
 		(property "Reference" "J6"
-			(at 237.49 52.0699 0)
+			(at 201.93 105.4099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13286,7 +15206,7 @@
 			)
 		)
 		(property "Value" "Conn_01x03_Pin"
-			(at 237.49 54.6099 0)
+			(at 201.93 107.9499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13295,7 +15215,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 236.22 53.34 0)
+			(at 200.66 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13304,7 +15224,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 236.22 53.34 0)
+			(at 200.66 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13313,7 +15233,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x03, script generated"
-			(at 236.22 53.34 0)
+			(at 200.66 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13891,16 +15811,16 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 243.84 53.34 0)
+		(at 267.97 34.29 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "ddcf8c7a-ef44-4057-9515-63bdf75efa58")
-		(property "Reference" "#PWR035"
-			(at 243.84 57.15 0)
+		(uuid "ddb6a9e6-6af1-4302-8659-8dc1188a8861")
+		(property "Reference" "#PWR038"
+			(at 267.97 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13908,8 +15828,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "+5V"
-			(at 243.84 48.26 0)
+		(property "Value" "VBATT"
+			(at 267.97 29.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13917,7 +15837,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 243.84 53.34 0)
+			(at 267.97 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13926,7 +15846,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 243.84 53.34 0)
+			(at 267.97 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13935,7 +15855,73 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 243.84 53.34 0)
+			(at 267.97 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6c4ee592-4e80-43b2-8c3d-81bac8237f5a")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "#PWR038")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 208.28 106.68 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ddcf8c7a-ef44-4057-9515-63bdf75efa58")
+		(property "Reference" "#PWR035"
+			(at 208.28 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 208.28 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 208.28 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 208.28 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 208.28 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14441,7 +16427,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 215.9 38.1 0)
+		(at 180.34 91.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -14450,7 +16436,7 @@
 		(fields_autoplaced yes)
 		(uuid "e83a28bd-66cb-43df-8e26-5a6dc79605b1")
 		(property "Reference" "#PWR031"
-			(at 215.9 41.91 0)
+			(at 180.34 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14459,7 +16445,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 215.9 33.02 0)
+			(at 180.34 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14467,7 +16453,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 215.9 38.1 0)
+			(at 180.34 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14476,7 +16462,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 215.9 38.1 0)
+			(at 180.34 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14485,7 +16471,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 215.9 38.1 0)
+			(at 180.34 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14943,6 +16929,159 @@
 			(project "blaze_io"
 				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
 					(reference "R22")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x30")
+		(at 274.32 71.12 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "fbec6dcd-a0a0-4c83-80a9-39ad173f1b43")
+		(property "Reference" "J8"
+			(at 276.86 71.1199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x30"
+			(at 278.13 84.328 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 274.32 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 274.32 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 274.32 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "5"
+			(uuid "8628fa07-75e0-435e-b790-9dad29d858d4")
+		)
+		(pin "20"
+			(uuid "35db7899-6914-460d-a6a5-17d481b0f62d")
+		)
+		(pin "24"
+			(uuid "6ed8d912-3ace-4171-baad-5839b8179186")
+		)
+		(pin "7"
+			(uuid "f0ee89ad-95ed-40c2-b7b3-2dc5b6afd34d")
+		)
+		(pin "4"
+			(uuid "593a8bae-7093-493f-8f9e-6dce5c2e6506")
+		)
+		(pin "3"
+			(uuid "5006e3e3-1269-4184-b25b-3978041e797e")
+		)
+		(pin "22"
+			(uuid "63cfd0a9-e188-411e-82f4-4ad4e1e15426")
+		)
+		(pin "16"
+			(uuid "29666e54-5d8b-428e-a498-0a355ee349d2")
+		)
+		(pin "23"
+			(uuid "6472904c-a099-4826-9bac-ab13e0f60be2")
+		)
+		(pin "21"
+			(uuid "f77c2bdf-9537-488f-863d-e691dd0aee49")
+		)
+		(pin "2"
+			(uuid "50acf634-499a-420c-9eb2-2672442e9727")
+		)
+		(pin "29"
+			(uuid "7333e1c6-7bb5-4ca0-8ef0-aa309442cfa2")
+		)
+		(pin "15"
+			(uuid "f084acd0-4833-495a-ab7b-7ed2bc980a29")
+		)
+		(pin "25"
+			(uuid "a3a6c62d-be6f-404f-a861-8fe38fc707c4")
+		)
+		(pin "6"
+			(uuid "001d7d06-bd66-4d6b-b39d-2c8c6da6bcac")
+		)
+		(pin "1"
+			(uuid "dfac6c72-32e3-4342-849a-f20078c9c94e")
+		)
+		(pin "12"
+			(uuid "8fe5abb2-9b19-4de3-ad32-cb3737b0282d")
+		)
+		(pin "11"
+			(uuid "024b71ac-a670-4800-b33a-93afb9e753a8")
+		)
+		(pin "8"
+			(uuid "8f024785-7c70-4761-b49f-f5d510776017")
+		)
+		(pin "10"
+			(uuid "85625f99-589f-4865-a639-da523c4a5a8c")
+		)
+		(pin "13"
+			(uuid "ae233c4b-cc0b-491f-a66a-f94d6bf59db8")
+		)
+		(pin "17"
+			(uuid "59b1b245-23ee-4351-b511-af32de820218")
+		)
+		(pin "26"
+			(uuid "4526ea52-0c45-493e-b5c6-de7aba229000")
+		)
+		(pin "28"
+			(uuid "b7c41d8e-a7c8-4ac3-8c00-86567e30c4c5")
+		)
+		(pin "18"
+			(uuid "f2ce4b59-3930-4232-8532-c258719ad838")
+		)
+		(pin "19"
+			(uuid "4e5feebf-c34a-450f-bc1e-85db4318fff7")
+		)
+		(pin "9"
+			(uuid "2d75fae2-38ab-4b0f-aade-2a7112d388be")
+		)
+		(pin "14"
+			(uuid "a803253f-269c-4a12-a246-0ab1b040da49")
+		)
+		(pin "27"
+			(uuid "ff266670-cdcb-4fcc-94ec-73b2d598dd2c")
+		)
+		(pin "30"
+			(uuid "1f628332-423f-4c1d-9a1e-94f11b4e188e")
+		)
+		(instances
+			(project "blaze_io"
+				(path "/364242f4-3b34-4bb6-a316-e0273e090451"
+					(reference "J8")
 					(unit 1)
 				)
 			)

--- a/hardware/blaze_power_managment/blaze_power_managment.kicad_sch
+++ b/hardware/blaze_power_managment/blaze_power_managment.kicad_sch
@@ -887,6 +887,957 @@
 				)
 			)
 		)
+		(symbol "Connector_Generic:Conn_01x30"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 38.1 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x30"
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x30_1_1"
+				(rectangle
+					(start -1.27 -37.973)
+					(end 0 -38.227)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -35.433)
+					(end 0 -35.687)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -32.893)
+					(end 0 -33.147)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -30.353)
+					(end 0 -30.607)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -27.813)
+					(end 0 -28.067)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -25.273)
+					(end 0 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -22.733)
+					(end 0 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 20.447)
+					(end 0 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 22.987)
+					(end 0 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 25.527)
+					(end 0 25.273)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 28.067)
+					(end 0 27.813)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 30.607)
+					(end 0 30.353)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 33.147)
+					(end 0 32.893)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 35.687)
+					(end 0 35.433)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 36.83)
+					(end 1.27 -39.37)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 35.56 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 33.02 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -22.86 0)
+					(length 3.81)
+					(name "Pin_24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -25.4 0)
+					(length 3.81)
+					(name "Pin_25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -27.94 0)
+					(length 3.81)
+					(name "Pin_26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -30.48 0)
+					(length 3.81)
+					(name "Pin_27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -33.02 0)
+					(length 3.81)
+					(name "Pin_28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -35.56 0)
+					(length 3.81)
+					(name "Pin_29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 30.48 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -38.1 0)
+					(length 3.81)
+					(name "Pin_30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 27.94 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 25.4 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 22.86 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 20.32 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "Connector_Generic:Conn_02x05_Odd_Even"
 			(pin_names
 				(offset 1.016) hide)
@@ -5268,6 +6219,12 @@
 		(uuid "303d1cce-e480-40cc-a32a-dcd2b91ad1be")
 	)
 	(junction
+		(at 246.38 86.36)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "33f3fb7f-93ba-42ac-9808-9be80837d10b")
+	)
+	(junction
 		(at 130.81 121.92)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5284,6 +6241,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "3807d785-2842-4bfc-afa5-def632e4e1de")
+	)
+	(junction
+		(at 246.38 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3a4ebce0-277b-4f4f-b4fb-61bf7883771c")
 	)
 	(junction
 		(at 48.26 138.43)
@@ -5308,6 +6271,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "411c4bb4-657c-471b-8a75-f5956697f6eb")
+	)
+	(junction
+		(at 246.38 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "41fe6807-31ab-4298-96bf-47a28663dd88")
 	)
 	(junction
 		(at 43.18 48.26)
@@ -5400,6 +6369,12 @@
 		(uuid "61cdd47b-95aa-457c-9bef-c25e05038d75")
 	)
 	(junction
+		(at 256.54 33.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "633ec975-7f5f-4e28-945e-abd3426969c0")
+	)
+	(junction
 		(at 143.51 129.54)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -5470,6 +6445,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "7d8c74cd-1363-401e-9b48-a35be19b97e1")
+	)
+	(junction
+		(at 246.38 99.06)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "817d41e0-b196-46aa-81b5-8b96bb8a4bcf")
 	)
 	(junction
 		(at 87.63 180.34)
@@ -5657,13 +6638,15 @@
 		(color 0 0 0 0)
 		(uuid "f9ee2772-a147-41d4-970e-f60ad3c8925b")
 	)
+	(junction
+		(at 241.3 104.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fff66aae-cb2b-4d26-ac72-4cc3443d0927")
+	)
 	(no_connect
 		(at 67.31 161.29)
 		(uuid "14e9c2bd-9055-47f6-a8bd-ed72fde783a3")
-	)
-	(no_connect
-		(at 67.31 166.37)
-		(uuid "1962e870-e7ff-4bee-bb48-fdc7f7ebb619")
 	)
 	(no_connect
 		(at 107.95 140.97)
@@ -5678,6 +6661,10 @@
 		(uuid "2544ccb3-f011-4980-a9ae-c3474567adc5")
 	)
 	(no_connect
+		(at 257.81 71.12)
+		(uuid "43c765b3-d895-44ae-a5e7-2a563aed6624")
+	)
+	(no_connect
 		(at 107.95 146.05)
 		(uuid "52e25656-2611-4825-86b5-a92211df878a")
 	)
@@ -5686,8 +6673,20 @@
 		(uuid "586bd21e-f64a-46cb-88df-c7acfbb09887")
 	)
 	(no_connect
+		(at 257.81 73.66)
+		(uuid "5eef3f6e-de6e-44c3-805b-10083d3e593d")
+	)
+	(no_connect
 		(at 107.95 135.89)
 		(uuid "65c79265-3c7e-4e5e-9f77-016c4800ec6f")
+	)
+	(no_connect
+		(at 257.81 45.72)
+		(uuid "696de942-3450-412c-9eca-259f3a36e265")
+	)
+	(no_connect
+		(at 257.81 53.34)
+		(uuid "72001aa0-9014-47de-b36c-28ec14546f9b")
 	)
 	(no_connect
 		(at 107.95 153.67)
@@ -5702,12 +6701,20 @@
 		(uuid "8355a016-48a5-49d1-9fba-d85b920b1f21")
 	)
 	(no_connect
+		(at 257.81 48.26)
+		(uuid "84412b07-0011-4b0b-b63a-62640da998d5")
+	)
+	(no_connect
 		(at 107.95 151.13)
 		(uuid "896f0cba-f368-412e-8584-c05314e3f0ab")
 	)
 	(no_connect
 		(at 67.31 140.97)
 		(uuid "8be58dbb-6c78-484b-b7d3-e158663a2831")
+	)
+	(no_connect
+		(at 257.81 96.52)
+		(uuid "9a1f9e8f-5391-4dc9-8859-4e3cc010a734")
 	)
 	(no_connect
 		(at 107.95 148.59)
@@ -5718,12 +6725,32 @@
 		(uuid "bd06ad2b-26c7-419b-9e38-8fc17094c7ca")
 	)
 	(no_connect
+		(at 257.81 43.18)
+		(uuid "c049d899-7477-4330-bb9f-63f696d57c31")
+	)
+	(no_connect
 		(at 67.31 146.05)
 		(uuid "d14a2e3e-31f7-448e-9b88-d87c3aa4c196")
 	)
 	(no_connect
 		(at 107.95 133.35)
 		(uuid "d40ee986-7d49-4398-9660-7ff056b26f7f")
+	)
+	(no_connect
+		(at 257.81 93.98)
+		(uuid "dfe79069-2c78-45e2-ba07-4b7687725f58")
+	)
+	(no_connect
+		(at 257.81 55.88)
+		(uuid "e23c0117-6582-4f5b-9059-d7989a6a315e")
+	)
+	(no_connect
+		(at 257.81 81.28)
+		(uuid "eaefa9b3-9dc8-4996-9c16-184dff0fbb95")
+	)
+	(no_connect
+		(at 257.81 78.74)
+		(uuid "f7d65c33-988c-4da2-8102-5b9c05e75829")
 	)
 	(wire
 		(pts
@@ -5877,6 +6904,26 @@
 	)
 	(wire
 		(pts
+			(xy 256.54 33.02) (xy 257.81 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11d0d7a2-e7f8-424f-a611-605748584dda")
+	)
+	(wire
+		(pts
+			(xy 246.38 41.91) (xy 246.38 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12c5481f-8a49-4ac8-9379-a7f593e1a3cd")
+	)
+	(wire
+		(pts
 			(xy 82.55 43.18) (xy 82.55 50.8)
 		)
 		(stroke
@@ -5884,6 +6931,16 @@
 			(type default)
 		)
 		(uuid "1399151f-f834-4c99-aad9-b5df6987c5b9")
+	)
+	(wire
+		(pts
+			(xy 246.38 86.36) (xy 257.81 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "142786c1-d01f-4695-b0d6-64bc810d2ca5")
 	)
 	(wire
 		(pts
@@ -5907,6 +6964,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 83.82) (xy 257.81 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16ae0aae-7de6-4506-a642-5ffdfe337ba9")
+	)
+	(wire
+		(pts
 			(xy 129.54 154.94) (xy 129.54 157.48)
 		)
 		(stroke
@@ -5924,6 +6991,16 @@
 			(type default)
 		)
 		(uuid "173247ff-7fac-4e22-adc1-d3040d3ced11")
+	)
+	(wire
+		(pts
+			(xy 252.73 91.44) (xy 257.81 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "19fefa9c-a612-4ec6-a3bc-dc686abefe47")
 	)
 	(wire
 		(pts
@@ -5997,6 +7074,16 @@
 	)
 	(wire
 		(pts
+			(xy 242.57 58.42) (xy 242.57 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22482072-b835-440a-9c78-a517b29305b9")
+	)
+	(wire
+		(pts
 			(xy 73.66 33.02) (xy 73.66 35.56)
 		)
 		(stroke
@@ -6057,6 +7144,16 @@
 	)
 	(wire
 		(pts
+			(xy 256.54 33.02) (xy 256.54 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "287edf92-3153-4102-b3d1-b4c43881497e")
+	)
+	(wire
+		(pts
 			(xy 123.19 45.72) (xy 123.19 50.8)
 		)
 		(stroke
@@ -6114,6 +7211,36 @@
 			(type default)
 		)
 		(uuid "2f544b1b-1e7e-416e-abbc-7e52d086fd94")
+	)
+	(wire
+		(pts
+			(xy 63.5 166.37) (xy 67.31 166.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2faae2db-2155-4edf-bd8a-c6acc0e5c422")
+	)
+	(wire
+		(pts
+			(xy 246.38 66.04) (xy 257.81 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2fc48f2d-d0b6-4898-adf0-c43e6eb093d6")
+	)
+	(wire
+		(pts
+			(xy 246.38 68.58) (xy 246.38 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "32975ff6-923e-4563-8840-831996a4ecd6")
 	)
 	(wire
 		(pts
@@ -6247,6 +7374,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 66.04) (xy 246.38 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e9b04a7-59ac-4098-a3cb-aabd6e13869e")
+	)
+	(wire
+		(pts
 			(xy 168.91 68.58) (xy 179.07 68.58)
 		)
 		(stroke
@@ -6254,6 +7391,16 @@
 			(type default)
 		)
 		(uuid "3ec791e2-5aa8-429e-95b8-e2735f70e4b3")
+	)
+	(wire
+		(pts
+			(xy 241.3 104.14) (xy 257.81 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3fe1f4b2-f10d-452c-aae5-53b347e7e4fb")
 	)
 	(wire
 		(pts
@@ -6527,6 +7674,16 @@
 	)
 	(wire
 		(pts
+			(xy 241.3 104.14) (xy 241.3 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e4b6b5a-70f9-410c-96d1-6355dc9d17aa")
+	)
+	(wire
+		(pts
 			(xy 252.73 144.78) (xy 254 144.78)
 		)
 		(stroke
@@ -6554,6 +7711,16 @@
 			(type default)
 		)
 		(uuid "63c076ef-e6c3-4747-8cdd-08849d2d1cc8")
+	)
+	(wire
+		(pts
+			(xy 241.3 99.06) (xy 241.3 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "641851c8-db17-45e8-b305-99fe37c768b5")
 	)
 	(wire
 		(pts
@@ -6697,6 +7864,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 99.06) (xy 257.81 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70e4008a-eff5-4fad-9e85-eb799bae6b9c")
+	)
+	(wire
+		(pts
 			(xy 123.19 50.8) (xy 100.33 50.8)
 		)
 		(stroke
@@ -6704,6 +7881,16 @@
 			(type default)
 		)
 		(uuid "72824285-94ab-48ee-801e-6a57875e5730")
+	)
+	(wire
+		(pts
+			(xy 256.54 35.56) (xy 257.81 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "731badd8-82a1-49c4-af4c-172989de7ac7")
 	)
 	(wire
 		(pts
@@ -6797,6 +7984,16 @@
 	)
 	(wire
 		(pts
+			(xy 254 63.5) (xy 257.81 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f2c9a55-4993-4c32-8065-7cf59273f622")
+	)
+	(wire
+		(pts
 			(xy 91.44 68.58) (xy 91.44 71.12)
 		)
 		(stroke
@@ -6814,6 +8011,16 @@
 			(type default)
 		)
 		(uuid "7f950c4b-245a-40c3-bad3-1ff548c2c88b")
+	)
+	(wire
+		(pts
+			(xy 246.38 40.64) (xy 257.81 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7fc84465-366e-4fb6-95ce-ed295392083a")
 	)
 	(wire
 		(pts
@@ -6907,6 +8114,16 @@
 	)
 	(wire
 		(pts
+			(xy 254 50.8) (xy 257.81 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9219cb5b-61ac-410c-9897-1206bcf0cafc")
+	)
+	(wire
+		(pts
 			(xy 82.55 33.02) (xy 82.55 35.56)
 		)
 		(stroke
@@ -6937,6 +8154,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 86.36) (xy 246.38 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94baaba8-f753-47e2-95a0-d8c6f9bb3709")
+	)
+	(wire
+		(pts
 			(xy 231.14 144.78) (xy 231.14 146.05)
 		)
 		(stroke
@@ -6954,6 +8181,16 @@
 			(type default)
 		)
 		(uuid "95f16588-7180-4d25-a15a-671b47069e8f")
+	)
+	(wire
+		(pts
+			(xy 246.38 68.58) (xy 257.81 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9632512d-d3ad-4c39-9567-bbb31fcf6fbf")
 	)
 	(wire
 		(pts
@@ -7027,6 +8264,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 99.06) (xy 246.38 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d416478-38f7-4fc9-93c9-56eda5cbc238")
+	)
+	(wire
+		(pts
 			(xy 132.08 35.56) (xy 132.08 33.02)
 		)
 		(stroke
@@ -7054,6 +8301,16 @@
 			(type default)
 		)
 		(uuid "a1452387-14c7-429e-a3d7-d14aa22242a8")
+	)
+	(wire
+		(pts
+			(xy 254 76.2) (xy 257.81 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2b7b1e9-b77f-4e2a-ac8f-a6afed9e3920")
 	)
 	(wire
 		(pts
@@ -7287,6 +8544,16 @@
 	)
 	(wire
 		(pts
+			(xy 252.73 88.9) (xy 257.81 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c345b5a5-c84d-4d15-bf36-357c3b731750")
+	)
+	(wire
+		(pts
 			(xy 186.69 50.8) (xy 179.07 50.8)
 		)
 		(stroke
@@ -7314,6 +8581,16 @@
 			(type default)
 		)
 		(uuid "c431dba4-0416-4588-9d91-60c1142f48e5")
+	)
+	(wire
+		(pts
+			(xy 257.81 38.1) (xy 246.38 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c61952c2-d8e5-496b-bbfc-a8695c22feb9")
 	)
 	(wire
 		(pts
@@ -7457,6 +8734,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 83.82) (xy 246.38 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1f3d7d9-fc15-4742-9506-3c9fd2186463")
+	)
+	(wire
+		(pts
 			(xy 179.07 50.8) (xy 168.91 50.8)
 		)
 		(stroke
@@ -7577,6 +8864,16 @@
 	)
 	(wire
 		(pts
+			(xy 241.3 106.68) (xy 257.81 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfa80c47-a813-4fe0-835e-67ebb90b9516")
+	)
+	(wire
+		(pts
 			(xy 100.33 86.36) (xy 99.06 86.36)
 		)
 		(stroke
@@ -7584,6 +8881,16 @@
 			(type default)
 		)
 		(uuid "e0a13221-9752-4101-82db-8f56415d02ed")
+	)
+	(wire
+		(pts
+			(xy 247.65 58.42) (xy 257.81 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0ad44d5-ce86-48a0-a26b-b578261aff9c")
 	)
 	(wire
 		(pts
@@ -7727,6 +9034,26 @@
 	)
 	(wire
 		(pts
+			(xy 242.57 60.96) (xy 257.81 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed47ca6f-57c9-4d47-9e12-dd184ff8f9f9")
+	)
+	(wire
+		(pts
+			(xy 246.38 38.1) (xy 246.38 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edb33067-398f-4f4a-9415-20d903c18c84")
+	)
+	(wire
+		(pts
 			(xy 254 143.51) (xy 255.27 143.51)
 		)
 		(stroke
@@ -7837,6 +9164,16 @@
 	)
 	(wire
 		(pts
+			(xy 246.38 101.6) (xy 257.81 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f7411c99-d78e-4586-87a6-fecf9090873c")
+	)
+	(wire
+		(pts
 			(xy 186.69 49.53) (xy 186.69 50.8)
 		)
 		(stroke
@@ -7884,6 +9221,16 @@
 			(type default)
 		)
 		(uuid "fe7aee8b-366f-48f3-b285-60e05f98d201")
+	)
+	(wire
+		(pts
+			(xy 256.54 31.75) (xy 256.54 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ff94be99-c0ea-4c77-8cdb-43c45b0e124b")
 	)
 	(label "TMS{slash}SWDAT"
 		(at 107.95 158.75 0)
@@ -8050,6 +9397,28 @@
 		)
 		(uuid "78c6fd1e-bbb2-4ab7-8b4b-823c5ab3fae3")
 	)
+	(label "PPS"
+		(at 257.81 63.5 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "791dd800-c3e9-4104-96ef-26d3e944d7a7")
+	)
+	(label "CANH"
+		(at 257.81 91.44 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7d7a2958-0cd6-43af-9adc-f2dd20303ef2")
+	)
 	(label "CANTX"
 		(at 207.01 147.32 180)
 		(fields_autoplaced yes)
@@ -8083,6 +9452,17 @@
 		)
 		(uuid "8a4fe5a7-7500-4dab-808e-aee7bc22eac3")
 	)
+	(label "PPS"
+		(at 67.31 166.37 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a49e2151-e3c1-410a-878e-4c562f01288f")
+	)
 	(label "3V3_SENSE_IN"
 		(at 26.67 72.39 180)
 		(fields_autoplaced yes)
@@ -8104,6 +9484,17 @@
 			(justify right bottom)
 		)
 		(uuid "acd763dd-00c6-4a3c-b9dc-95af7fa7fa35")
+	)
+	(label "CANL"
+		(at 257.81 88.9 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "b6314f87-ef76-474f-9df9-4ac2859b7757")
 	)
 	(label "BOOT"
 		(at 36.83 161.29 180)
@@ -8181,6 +9572,17 @@
 			(justify left bottom)
 		)
 		(uuid "eae69325-bff4-4ea1-81c2-988906d399fc")
+	)
+	(label "ARM"
+		(at 257.81 50.8 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "ebeeef60-e67a-4de6-b95d-db048bbcb00a")
 	)
 	(label "5V_SENSE_IN"
 		(at 26.67 74.93 180)
@@ -8821,6 +10223,159 @@
 		)
 	)
 	(symbol
+		(lib_id "Connector_Generic:Conn_01x30")
+		(at 262.89 68.58 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "133d4c35-e76b-482e-9b20-90ab6c0b5554")
+		(property "Reference" "J3"
+			(at 265.43 68.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x30"
+			(at 266.7 81.788 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "5"
+			(uuid "889027b0-ee8b-4109-93f6-a415d421c34d")
+		)
+		(pin "20"
+			(uuid "b14f9d8d-213b-4cbf-a855-a64d69b956c8")
+		)
+		(pin "24"
+			(uuid "192bbe6d-c0b4-41b0-9f2e-c0dbee7ea6ba")
+		)
+		(pin "7"
+			(uuid "fc244caa-8813-4890-b905-bc28bd235cc9")
+		)
+		(pin "4"
+			(uuid "76fe3ae8-413c-4434-8e8a-ff2fc72e94ea")
+		)
+		(pin "3"
+			(uuid "88941a5a-9810-4179-8b74-ceaf84002a9b")
+		)
+		(pin "22"
+			(uuid "669ef705-016b-4f54-862b-644cbe272f40")
+		)
+		(pin "16"
+			(uuid "ca514e42-d04e-426d-b421-4ca1ff0bbae0")
+		)
+		(pin "23"
+			(uuid "5b6bde80-7589-4370-8188-06f9644325e4")
+		)
+		(pin "21"
+			(uuid "f4a1e7eb-655d-4540-aad1-287a44896d44")
+		)
+		(pin "2"
+			(uuid "eb5dd2cf-7045-4bfe-98ca-d806c7579cad")
+		)
+		(pin "29"
+			(uuid "277d192a-43e4-4076-9021-28283688e0f9")
+		)
+		(pin "15"
+			(uuid "9af95a46-9fbd-4e20-81ee-1627b1720bcb")
+		)
+		(pin "25"
+			(uuid "f1d0c9bc-fd55-4416-8ebe-8eaec9629309")
+		)
+		(pin "6"
+			(uuid "cb08185c-ae01-4330-8612-290cfb6caa04")
+		)
+		(pin "1"
+			(uuid "efc314a4-3357-4a81-b68e-508cbc9f4752")
+		)
+		(pin "12"
+			(uuid "b7669627-1ac1-4e03-af4b-9fc1abdfb87c")
+		)
+		(pin "11"
+			(uuid "b89390f8-9352-4255-bf46-eb00947c57a5")
+		)
+		(pin "8"
+			(uuid "7012c723-de65-40d0-b1ff-69342823add1")
+		)
+		(pin "10"
+			(uuid "864e27e8-9ffe-4418-a21d-eba8aa9a3fe9")
+		)
+		(pin "13"
+			(uuid "5155f0be-e485-4655-a871-ea044a3e27f2")
+		)
+		(pin "17"
+			(uuid "897f0977-c6ae-4d4b-b2fc-fe29f944a20a")
+		)
+		(pin "26"
+			(uuid "e2dac5d0-7934-46b3-ab52-78a270203bba")
+		)
+		(pin "28"
+			(uuid "1703c07e-a34e-471e-a91b-b4ae3c01a311")
+		)
+		(pin "18"
+			(uuid "e31a27b5-6cb6-49c2-b287-42f0c6ea33c3")
+		)
+		(pin "19"
+			(uuid "45e4f6da-faa7-4dcc-ba83-0b0a5bbc400c")
+		)
+		(pin "9"
+			(uuid "6c58218a-3924-4171-a78d-cdf6db55efa7")
+		)
+		(pin "14"
+			(uuid "af99f9a9-973d-4c94-aae1-a66dd8127a70")
+		)
+		(pin "27"
+			(uuid "9d1f038e-d9e8-4d85-b2f2-50f117b47376")
+		)
+		(pin "30"
+			(uuid "073e958e-a508-4384-bbd5-1aa56f8b612b")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "J3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Blaze_Lib:TPS62913")
 		(at 111.76 39.37 0)
 		(unit 1)
@@ -9046,6 +10601,72 @@
 			(project "blaze_power_managment"
 				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
 					(reference "C5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 242.57 58.42 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1ed26f22-b6a9-41cf-b984-9a0d0d6209b7")
+		(property "Reference" "#PWR016"
+			(at 242.57 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 242.57 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 242.57 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 242.57 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 242.57 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3cdcf472-50ea-4d3f-ada2-c6ab175e6562")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR016")
 					(unit 1)
 				)
 			)
@@ -9702,6 +11323,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 246.38 69.85 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3545358e-afd3-49e2-ab67-70d686238b8e")
+		(property "Reference" "#PWR033"
+			(at 246.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 246.38 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 246.38 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 246.38 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 246.38 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9d6ec519-8a4c-408b-a8c8-7c2391909cdb")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR033")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:D_Zener")
 		(at 48.26 36.83 270)
 		(unit 1)
@@ -9902,6 +11589,72 @@
 			(project "blaze_power_managment"
 				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
 					(reference "L2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 256.54 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ba6e597-c8ca-4af4-99ed-2c09bb510c08")
+		(property "Reference" "#PWR014"
+			(at 256.54 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VBATT"
+			(at 256.54 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 256.54 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 256.54 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 256.54 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f5bcaf93-fa8a-4cfc-bdbf-5b72fd70f0de")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR014")
 					(unit 1)
 				)
 			)
@@ -11053,6 +12806,71 @@
 			(project "blaze_power_managment"
 				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
 					(reference "#PWR018")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 246.38 99.06 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "67f93956-7f15-4954-bc33-78c997fbbfc0")
+		(property "Reference" "#PWR039"
+			(at 246.38 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 246.38 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 246.38 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 246.38 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 246.38 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae41b7d1-a05c-4818-89f6-09d7211cedc7")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR039")
 					(unit 1)
 				)
 			)
@@ -12214,6 +14032,138 @@
 	)
 	(symbol
 		(lib_id "power:GND")
+		(at 246.38 41.91 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b8af9ee1-8458-4887-b907-c08362291677")
+		(property "Reference" "#PWR015"
+			(at 246.38 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 246.38 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 246.38 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 246.38 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 246.38 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c42d12d0-92b1-43b4-bc96-e9e3bff49df2")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR015")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 241.3 99.06 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bc4daa40-d2b3-467b-ae63-c776d93970a7")
+		(property "Reference" "#PWR038"
+			(at 241.3 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 241.3 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 241.3 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 241.3 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "89a25334-aa48-4bc9-84b1-898dcd7710c1")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR038")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
 		(at 60.96 76.2 0)
 		(unit 1)
 		(exclude_from_sim no)
@@ -12888,6 +14838,71 @@
 			(project "blaze_power_managment"
 				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
 					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 246.38 87.63 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d1f5be24-7535-4cdd-bc25-c16b89fa1206")
+		(property "Reference" "#PWR037"
+			(at 246.38 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 246.38 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 246.38 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 246.38 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 246.38 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7177df65-ebee-4004-8169-06e38afc005f")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR037")
 					(unit 1)
 				)
 			)
@@ -14120,6 +16135,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 254 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f6396798-f69e-456f-87f2-4ca42d5fc926")
+		(property "Reference" "#PWR034"
+			(at 254 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 254 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 254 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 254 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 254 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8a8530dc-0e12-4b24-b89b-d10b960ddb10")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR034")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
 		(at 128.27 73.66 90)
 		(unit 1)
@@ -14181,6 +16262,72 @@
 			(project "blaze_power_managment"
 				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
 					(reference "R9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 247.65 58.42 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f9b3ce3d-1291-4f38-b552-fa3cf8e409a7")
+		(property "Reference" "#PWR017"
+			(at 247.65 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 247.65 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 247.65 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 247.65 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 247.65 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2a44e2-cf0f-4cfa-8391-c6992155a53f")
+		)
+		(instances
+			(project "blaze_power_managment"
+				(path "/bbae2fc8-66b1-443e-aca5-c1307d525987"
+					(reference "#PWR017")
 					(unit 1)
 				)
 			)

--- a/hardware/blaze_radio/blaze_radio.kicad_sch
+++ b/hardware/blaze_radio/blaze_radio.kicad_sch
@@ -363,6 +363,957 @@
 				)
 			)
 		)
+		(symbol "Connector_Generic:Conn_01x30"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 38.1 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x30"
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x30_1_1"
+				(rectangle
+					(start -1.27 -37.973)
+					(end 0 -38.227)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -35.433)
+					(end 0 -35.687)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -32.893)
+					(end 0 -33.147)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -30.353)
+					(end 0 -30.607)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -27.813)
+					(end 0 -28.067)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -25.273)
+					(end 0 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -22.733)
+					(end 0 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 20.447)
+					(end 0 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 22.987)
+					(end 0 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 25.527)
+					(end 0 25.273)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 28.067)
+					(end 0 27.813)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 30.607)
+					(end 0 30.353)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 33.147)
+					(end 0 32.893)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 35.687)
+					(end 0 35.433)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 36.83)
+					(end 1.27 -39.37)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 35.56 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 33.02 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -22.86 0)
+					(length 3.81)
+					(name "Pin_24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -25.4 0)
+					(length 3.81)
+					(name "Pin_25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -27.94 0)
+					(length 3.81)
+					(name "Pin_26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -30.48 0)
+					(length 3.81)
+					(name "Pin_27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -33.02 0)
+					(length 3.81)
+					(name "Pin_28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -35.56 0)
+					(length 3.81)
+					(name "Pin_29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 30.48 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -38.1 0)
+					(length 3.81)
+					(name "Pin_30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 27.94 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 25.4 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 22.86 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 20.32 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "Device:C"
 			(pin_numbers hide)
 			(pin_names
@@ -849,6 +1800,24 @@
 		(uuid "5a0c6e00-6d75-479c-b42a-b6876c5157b2")
 	)
 	(junction
+		(at 163.83 29.21)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5c8ecc70-2e53-416c-b927-8c88d0d3035c")
+	)
+	(junction
+		(at 163.83 87.63)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6b0f9932-8358-49dd-b7fd-a4adca8ef3de")
+	)
+	(junction
+		(at 163.83 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b926bda6-872c-4ce3-af1b-97ef08f5bb88")
+	)
+	(junction
 		(at 121.92 68.58)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -860,25 +1829,97 @@
 		(color 0 0 0 0)
 		(uuid "bebe8403-b91e-42a7-bf84-b272f4feb705")
 	)
+	(junction
+		(at 158.75 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c78d0d69-c40b-45be-b97c-f99689a3edfb")
+	)
+	(junction
+		(at 163.83 57.15)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f05d802e-f7a7-449a-ad9a-c19447a8e2c1")
+	)
 	(no_connect
 		(at 105.41 67.31)
 		(uuid "14b0ac72-3323-49f0-8f8b-a33e59d01b5b")
+	)
+	(no_connect
+		(at 175.26 44.45)
+		(uuid "16514bb1-0be6-4e07-8d74-d5c25182e50f")
+	)
+	(no_connect
+		(at 175.26 52.07)
+		(uuid "31f42aed-8979-4297-9af6-73001679157a")
+	)
+	(no_connect
+		(at 175.26 62.23)
+		(uuid "3e53344d-cc84-48b5-b735-a7e08fdf5a69")
+	)
+	(no_connect
+		(at 175.26 39.37)
+		(uuid "3e6f9420-0ca8-4a19-ab49-4984303da0a3")
 	)
 	(no_connect
 		(at 105.41 59.69)
 		(uuid "44af6fea-809b-4e99-b27c-c5cf3add8a06")
 	)
 	(no_connect
+		(at 175.26 41.91)
+		(uuid "4ebeaf8f-1646-469d-ae85-23fe3ee96645")
+	)
+	(no_connect
+		(at 175.26 80.01)
+		(uuid "54717772-8bbf-4105-ab64-67380960c38c")
+	)
+	(no_connect
+		(at 175.26 82.55)
+		(uuid "60d7bc8b-3eab-4b20-b023-607e8313d195")
+	)
+	(no_connect
+		(at 175.26 77.47)
+		(uuid "822a394f-c367-44b9-823a-696441ffe259")
+	)
+	(no_connect
+		(at 175.26 67.31)
+		(uuid "a937869f-2f41-4827-acf2-caf5d9ba3243")
+	)
+	(no_connect
+		(at 175.26 69.85)
+		(uuid "aee700ff-cc57-412f-aa1d-8bdb433e2b35")
+	)
+	(no_connect
+		(at 175.26 59.69)
+		(uuid "b84703d6-26ba-4c76-89c7-5bcd2346f464")
+	)
+	(no_connect
+		(at 175.26 36.83)
+		(uuid "c271bb80-ee9f-47d3-a9fa-a5983f97bc07")
+	)
+	(no_connect
 		(at 105.41 62.23)
 		(uuid "c74e22f8-e8bb-444f-b087-101460e4dd89")
+	)
+	(no_connect
+		(at 175.26 85.09)
+		(uuid "c9eed527-3eff-43be-92c6-542df103ecfd")
 	)
 	(no_connect
 		(at 105.41 64.77)
 		(uuid "d61c5c3b-8000-4ff9-a55c-334de2a0bb5e")
 	)
 	(no_connect
+		(at 175.26 24.13)
+		(uuid "d6d096c7-80e7-48d8-b80c-c81ec85b24c7")
+	)
+	(no_connect
 		(at 105.41 57.15)
 		(uuid "d7a40626-4eed-495a-861f-5fdc77b8469f")
+	)
+	(no_connect
+		(at 175.26 21.59)
+		(uuid "dcc12b44-33ab-43b0-b50d-1095b3029086")
 	)
 	(no_connect
 		(at 86.36 67.31)
@@ -914,6 +1955,26 @@
 	)
 	(wire
 		(pts
+			(xy 166.37 31.75) (xy 175.26 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e292935-bb5c-4c4f-a476-952bd285c42d")
+	)
+	(wire
+		(pts
+			(xy 163.83 72.39) (xy 175.26 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13de2412-9355-45a9-a7ff-3bb9309d80f4")
+	)
+	(wire
+		(pts
 			(xy 106.68 77.47) (xy 105.41 77.47)
 		)
 		(stroke
@@ -934,6 +1995,56 @@
 	)
 	(wire
 		(pts
+			(xy 163.83 57.15) (xy 163.83 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2078768d-7cab-4e4a-b746-fd6cd5685e36")
+	)
+	(wire
+		(pts
+			(xy 160.02 46.99) (xy 160.02 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "241ef817-3cf6-43ea-bf0e-9a508303bf94")
+	)
+	(wire
+		(pts
+			(xy 163.83 54.61) (xy 175.26 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26b9e344-cde1-4112-87d5-1a6a46c5121c")
+	)
+	(wire
+		(pts
+			(xy 158.75 92.71) (xy 175.26 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "526967fa-264e-4408-bf60-9776eed21913")
+	)
+	(wire
+		(pts
+			(xy 163.83 54.61) (xy 163.83 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55956bf9-8fbe-45b9-a7a5-6a3c84864d6b")
+	)
+	(wire
+		(pts
 			(xy 115.57 68.58) (xy 121.92 68.58)
 		)
 		(stroke
@@ -944,13 +2055,13 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 74.93) (xy 86.36 74.93)
+			(xy 163.83 87.63) (xy 163.83 90.17)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "5fccd2e3-4927-4b3b-b562-38339d974987")
+		(uuid "5e60d50b-b9be-4f45-b6fd-d1114a15bb3f")
 	)
 	(wire
 		(pts
@@ -964,6 +2075,46 @@
 	)
 	(wire
 		(pts
+			(xy 163.83 29.21) (xy 175.26 29.21)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6a656f02-d07d-4ddf-8a88-25181c5e266b")
+	)
+	(wire
+		(pts
+			(xy 77.47 74.93) (xy 86.36 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "71b7111d-3d3c-4153-b912-4bf29c219910")
+	)
+	(wire
+		(pts
+			(xy 163.83 74.93) (xy 175.26 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "724287e4-8d8e-4017-9442-4cea7fbf1d36")
+	)
+	(wire
+		(pts
+			(xy 163.83 87.63) (xy 175.26 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79b4d517-0434-4088-9d3d-0edff3ace76d")
+	)
+	(wire
+		(pts
 			(xy 106.68 74.93) (xy 105.41 74.93)
 		)
 		(stroke
@@ -971,6 +2122,16 @@
 			(type default)
 		)
 		(uuid "7f2dd397-eff1-4320-851c-8c65b94118fe")
+	)
+	(wire
+		(pts
+			(xy 158.75 92.71) (xy 158.75 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81252c8a-bfa6-4a46-b46b-11ebb2da8c02")
 	)
 	(wire
 		(pts
@@ -984,6 +2145,26 @@
 	)
 	(wire
 		(pts
+			(xy 163.83 57.15) (xy 175.26 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "98806ab7-0d47-430f-830e-fa9161a26e2d")
+	)
+	(wire
+		(pts
+			(xy 171.45 64.77) (xy 175.26 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d829f30-b17d-42ee-a9b1-87d55bf99502")
+	)
+	(wire
+		(pts
 			(xy 106.68 72.39) (xy 105.41 72.39)
 		)
 		(stroke
@@ -994,13 +2175,63 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 77.47) (xy 86.36 77.47)
+			(xy 166.37 34.29) (xy 175.26 34.29)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c59579b0-7ad8-417b-9573-9c8927a2fdd0")
+		(uuid "aec17671-0235-4338-8723-a88ca1294e1c")
+	)
+	(wire
+		(pts
+			(xy 163.83 72.39) (xy 163.83 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b100c1fa-79ea-4642-b49e-55179bc848ca")
+	)
+	(wire
+		(pts
+			(xy 158.75 87.63) (xy 158.75 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b32e9117-c8cd-4e63-a0d7-7481c2f796a4")
+	)
+	(wire
+		(pts
+			(xy 158.75 95.25) (xy 175.26 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3775517-b688-420e-b49c-1ab0fcad4c1e")
+	)
+	(wire
+		(pts
+			(xy 163.83 26.67) (xy 163.83 29.21)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d7b98aea-82a3-48d1-aead-7df2cd78948a")
+	)
+	(wire
+		(pts
+			(xy 163.83 74.93) (xy 163.83 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0142129-0643-41b5-946e-f75c284023bd")
 	)
 	(wire
 		(pts
@@ -1014,6 +2245,26 @@
 	)
 	(wire
 		(pts
+			(xy 163.83 30.48) (xy 163.83 29.21)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e45a3e8a-4f49-4419-a533-db2de7db6d62")
+	)
+	(wire
+		(pts
+			(xy 77.47 77.47) (xy 86.36 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef6b464f-3697-44f0-96f8-f0f5d47e50b2")
+	)
+	(wire
+		(pts
 			(xy 106.68 77.47) (xy 106.68 74.93)
 		)
 		(stroke
@@ -1022,8 +2273,48 @@
 		)
 		(uuid "f1791ba9-2e35-4316-8b02-602b90c6eb0d")
 	)
-	(label "TX"
-		(at 139.7 66.04 180)
+	(wire
+		(pts
+			(xy 175.26 26.67) (xy 163.83 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f91fe89e-53b4-4711-b641-356135e129be")
+	)
+	(wire
+		(pts
+			(xy 163.83 90.17) (xy 175.26 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fc42e8ad-4c24-4e9b-bdcb-0914cf5e4077")
+	)
+	(wire
+		(pts
+			(xy 165.1 46.99) (xy 175.26 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd638aad-9da1-4944-a03d-8a4dd3855be6")
+	)
+	(wire
+		(pts
+			(xy 160.02 49.53) (xy 175.26 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fdf12d0a-ebd4-49b6-bf8b-4b58c68472e5")
+	)
+	(label "RX_RADIO"
+		(at 175.26 34.29 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -1031,9 +2322,9 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "04a290cf-7a7b-48eb-bcd3-1ce14df69c5b")
+		(uuid "0ca38185-f9a1-49a5-9e16-3b03e4efa193")
 	)
-	(label "TX"
+	(label "TX_RADIO"
 		(at 86.36 77.47 180)
 		(fields_autoplaced yes)
 		(effects
@@ -1042,9 +2333,9 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "0f72a972-4bb4-4eef-953d-57221631d015")
+		(uuid "43e6794c-fa86-4d29-8d1a-95069984554d")
 	)
-	(label "RX"
+	(label "RX_RADIO"
 		(at 86.36 74.93 180)
 		(fields_autoplaced yes)
 		(effects
@@ -1053,10 +2344,10 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "1a7d778c-2146-4428-a8f5-ec89599a342b")
+		(uuid "5b41e9ca-96e3-4410-985e-3a5bc62303dd")
 	)
-	(label "RX"
-		(at 139.7 63.5 180)
+	(label "TX_RADIO"
+		(at 175.26 31.75 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -1064,7 +2355,7 @@
 			)
 			(justify right bottom)
 		)
-		(uuid "6761bd9d-0320-45ae-b351-563bcf81172d")
+		(uuid "cb8c2554-7b54-4fc7-a4c7-f69f73d8da1f")
 	)
 	(symbol
 		(lib_id "power:GND")
@@ -1199,6 +2490,137 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 163.83 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "28cb2814-fe2b-4650-9e25-09592f27c7a1")
+		(property "Reference" "#PWR013"
+			(at 163.83 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 163.83 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 163.83 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 163.83 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "57927fd0-1a58-4449-a2fa-998a1d611644")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR013")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 165.1 46.99 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2adf911a-5074-4f4e-8aaf-0db520368815")
+		(property "Reference" "#PWR010"
+			(at 165.1 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 165.1 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 165.1 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 165.1 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f865a6d1-0cd9-483b-ab35-7aadc7864725")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR010")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:C")
 		(at 121.92 64.77 0)
 		(unit 1)
@@ -1262,6 +2684,137 @@
 			(project "blaze_radio"
 				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
 					(reference "C2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 163.83 87.63 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "43784af4-9a4f-44d0-a2f2-84f6a3829574")
+		(property "Reference" "#PWR015"
+			(at 163.83 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 163.83 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 163.83 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 163.83 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "03ddfff0-a21d-4174-b4b3-f3d5a7eaf9af")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR015")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 163.83 30.48 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "467b4705-2c80-4a23-86d7-475bc5d28f43")
+		(property "Reference" "#PWR08"
+			(at 163.83 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 163.83 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 163.83 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 163.83 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "de64829e-ceaf-469a-b27a-dddec5827900")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR08")
 					(unit 1)
 				)
 			)
@@ -1404,6 +2957,72 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
+		(at 160.02 46.99 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "65de2be6-03eb-4e0d-83ae-1d3ab5312c8c")
+		(property "Reference" "#PWR09"
+			(at 160.02 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 160.02 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 160.02 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 160.02 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9d911b66-3509-42c4-b182-83e5a26f2f3f")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR09")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
 		(at 81.28 57.15 0)
 		(unit 1)
 		(exclude_from_sim no)
@@ -1463,6 +3082,72 @@
 			(project ""
 				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
 					(reference "#PWR03")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 163.83 58.42 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "79f85c06-2f9c-4751-bbf1-2c901142c2f5")
+		(property "Reference" "#PWR011"
+			(at 163.83 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 163.83 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 163.83 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 163.83 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f74c8f32-2a15-4b1d-95ea-12eee85164fd")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR011")
 					(unit 1)
 				)
 			)
@@ -1601,6 +3286,225 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 158.75 87.63 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9b4b19ab-6498-4132-bcf1-da5f1c110d0d")
+		(property "Reference" "#PWR014"
+			(at 158.75 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 158.75 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 158.75 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 158.75 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 158.75 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1e799253-44b0-4ae7-b382-f30995c33fd3")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR014")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x30")
+		(at 180.34 57.15 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ba207e40-4a33-41b2-9cd7-e2a53ff5ed08")
+		(property "Reference" "J1"
+			(at 182.88 57.1499 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x30"
+			(at 184.15 70.358 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "5"
+			(uuid "dcf30f76-514c-4cbd-8014-ea454a3dfc64")
+		)
+		(pin "20"
+			(uuid "6d9e2f42-5674-4247-9d5e-baf5b3318f15")
+		)
+		(pin "24"
+			(uuid "c9e725d1-547e-48a9-b126-982b79c66d79")
+		)
+		(pin "7"
+			(uuid "9841facc-74cf-4328-8169-cbc0e03483fb")
+		)
+		(pin "4"
+			(uuid "1635d23d-2746-4345-b903-a596a36989c5")
+		)
+		(pin "3"
+			(uuid "d84fceb4-26fd-49f9-adc1-ae0b4f0d67f6")
+		)
+		(pin "22"
+			(uuid "a3791dae-281e-4fb0-9104-9e1e2277e8f5")
+		)
+		(pin "16"
+			(uuid "980461ab-8aa9-466e-965e-162ab6c4913f")
+		)
+		(pin "23"
+			(uuid "2ca9cb26-fbd8-4276-a2a6-65c1c9301b63")
+		)
+		(pin "21"
+			(uuid "3b60de09-5c89-4b08-b7d8-5f5700f7d7a9")
+		)
+		(pin "2"
+			(uuid "310c3fc5-b6b1-445d-9c82-11074fa5bf70")
+		)
+		(pin "29"
+			(uuid "da9fd3dc-4538-462a-b789-ca9d3fcc3fb0")
+		)
+		(pin "15"
+			(uuid "3ebe5a75-8896-471e-ab5b-8f62e1adfe97")
+		)
+		(pin "25"
+			(uuid "4977cd27-7847-4c31-a866-3afaf8f1e121")
+		)
+		(pin "6"
+			(uuid "8d29ff74-4aa7-458f-a9f2-452857fa221a")
+		)
+		(pin "1"
+			(uuid "df5601b7-84c2-486b-8ed1-a3098f75a6ed")
+		)
+		(pin "12"
+			(uuid "b52c8dd8-c306-4741-82c6-0b714ef32f6e")
+		)
+		(pin "11"
+			(uuid "ec9747ce-f8d3-42ba-aa6e-2fbb79d1d60e")
+		)
+		(pin "8"
+			(uuid "eb4aa42d-ea6a-46c5-83f5-dcff93e35cc5")
+		)
+		(pin "10"
+			(uuid "ffeaf9f9-66d8-4c57-a906-8c39361d88ee")
+		)
+		(pin "13"
+			(uuid "837995f9-7204-43eb-b39c-0d582e125182")
+		)
+		(pin "17"
+			(uuid "7a37fc00-845d-4229-adef-f51123477ff8")
+		)
+		(pin "26"
+			(uuid "34633f31-3018-49a7-8c67-80ec78de408b")
+		)
+		(pin "28"
+			(uuid "a3b2654e-c17e-4890-9823-e1dab1fbc97d")
+		)
+		(pin "18"
+			(uuid "aefcec69-5eac-45ee-b6ba-4b2644be5509")
+		)
+		(pin "19"
+			(uuid "7d78d384-068c-4d6d-9d71-cfd6c18d011c")
+		)
+		(pin "9"
+			(uuid "c88ed15d-6761-4e6b-aff0-e4980212752a")
+		)
+		(pin "14"
+			(uuid "07a2f521-aac3-469d-b4d0-e62e6456a21e")
+		)
+		(pin "27"
+			(uuid "3a085457-3391-43cc-85d8-de527faff85c")
+		)
+		(pin "30"
+			(uuid "74a3c65c-21bb-47de-9cfa-b64ac0a6a94a")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Blaze_Lib:RFD900X")
 		(at 95.25 67.31 0)
 		(unit 1)
@@ -1705,6 +3609,72 @@
 			(project ""
 				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
 					(reference "U1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 171.45 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb443d87-d60f-486a-844b-be80e189b6ad")
+		(property "Reference" "#PWR012"
+			(at 171.45 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 171.45 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 171.45 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 171.45 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 171.45 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "392f0954-6f13-4dd1-96c0-36365cc34868")
+		)
+		(instances
+			(project "blaze_radio"
+				(path "/30c73abf-9ac3-4d0a-90b9-0c45ca2fec26"
+					(reference "#PWR012")
 					(unit 1)
 				)
 			)

--- a/hardware/blaze_sense/blaze_sense.kicad_sch
+++ b/hardware/blaze_sense/blaze_sense.kicad_sch
@@ -2331,6 +2331,957 @@
 				)
 			)
 		)
+		(symbol "Connector_Generic:Conn_01x30"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 38.1 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x30"
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x30_1_1"
+				(rectangle
+					(start -1.27 -37.973)
+					(end 0 -38.227)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -35.433)
+					(end 0 -35.687)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -32.893)
+					(end 0 -33.147)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -30.353)
+					(end 0 -30.607)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -27.813)
+					(end 0 -28.067)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -25.273)
+					(end 0 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -22.733)
+					(end 0 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 20.447)
+					(end 0 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 22.987)
+					(end 0 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 25.527)
+					(end 0 25.273)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 28.067)
+					(end 0 27.813)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 30.607)
+					(end 0 30.353)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 33.147)
+					(end 0 32.893)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 35.687)
+					(end 0 35.433)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 36.83)
+					(end 1.27 -39.37)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 35.56 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 33.02 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -22.86 0)
+					(length 3.81)
+					(name "Pin_24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -25.4 0)
+					(length 3.81)
+					(name "Pin_25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -27.94 0)
+					(length 3.81)
+					(name "Pin_26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -30.48 0)
+					(length 3.81)
+					(name "Pin_27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -33.02 0)
+					(length 3.81)
+					(name "Pin_28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -35.56 0)
+					(length 3.81)
+					(name "Pin_29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 30.48 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -38.1 0)
+					(length 3.81)
+					(name "Pin_30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 27.94 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 25.4 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 22.86 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 20.32 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "Connector_Generic:Conn_02x05_Odd_Even"
 			(pin_names
 				(offset 1.016) hide)
@@ -9051,6 +10002,126 @@
 				)
 			)
 		)
+		(symbol "power:+5V"
+			(power)
+			(pin_numbers hide)
+			(pin_names
+				(offset 0) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
 		(symbol "power:GND"
 			(power)
 			(pin_numbers hide)
@@ -9287,6 +10358,12 @@
 		(uuid "2faf4aa5-f874-40eb-a997-837b87634a63")
 	)
 	(junction
+		(at 373.38 196.85)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "309a8e94-aef8-425e-8b3c-4281caa92d92")
+	)
+	(junction
 		(at 187.96 114.3)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -9303,6 +10380,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "418c9558-e19b-4f1e-85d8-6f3c8044642b")
+	)
+	(junction
+		(at 378.46 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "418fa9c0-8f05-4859-a4a2-30df5add13b8")
 	)
 	(junction
 		(at 191.77 22.86)
@@ -9473,6 +10556,12 @@
 		(uuid "89b978a8-9fd2-4b43-beb0-625e76df494b")
 	)
 	(junction
+		(at 378.46 133.35)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8a2dc982-1ec1-4f1d-9c2c-7c821b187d2c")
+	)
+	(junction
 		(at 90.17 31.75)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -9563,6 +10652,12 @@
 		(uuid "af2c1f5f-c6f2-46f2-8428-f36ffd003f60")
 	)
 	(junction
+		(at 378.46 161.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "af96416a-2d93-48ff-9e5a-ce7ee6032fef")
+	)
+	(junction
 		(at 233.68 124.46)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -9573,6 +10668,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "b87a6204-5b92-4672-9aac-cdc3394a209a")
+	)
+	(junction
+		(at 378.46 179.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b976b62d-812e-40c6-9d21-66c6ae7af65d")
 	)
 	(junction
 		(at 20.32 104.14)
@@ -9785,16 +10886,16 @@
 		(uuid "ff2356dd-d346-478f-a458-8085446b27a1")
 	)
 	(no_connect
+		(at 389.89 128.27)
+		(uuid "005881f6-92e2-4ef8-9ee1-dc40ebb0791c")
+	)
+	(no_connect
 		(at 62.23 182.88)
 		(uuid "05e7e79d-66a4-482f-a0a3-62aaf7617a97")
 	)
 	(no_connect
 		(at 62.23 200.66)
 		(uuid "07472c17-5f99-4332-9ba9-2f09de4f48b5")
-	)
-	(no_connect
-		(at 133.35 86.36)
-		(uuid "07487980-3eeb-45c9-b730-cf213f15ef3f")
 	)
 	(no_connect
 		(at 62.23 167.64)
@@ -9873,6 +10974,10 @@
 		(uuid "2c6a7066-500c-4c1b-ab89-0be346c5fc15")
 	)
 	(no_connect
+		(at 389.89 148.59)
+		(uuid "2da5b942-3230-4955-8516-402f9db802cd")
+	)
+	(no_connect
 		(at 133.35 243.84)
 		(uuid "30811f50-f688-4c7c-8b3b-a3d83a21c9d7")
 	)
@@ -9929,6 +11034,10 @@
 		(uuid "4d37b787-217e-4e0e-9f31-0fcfa0ff3e26")
 	)
 	(no_connect
+		(at 389.89 163.83)
+		(uuid "4e27774d-3f63-4075-9f29-3d4121d7dc64")
+	)
+	(no_connect
 		(at 62.23 185.42)
 		(uuid "4e44fec0-bb55-485e-b1c9-87e9082cbe3b")
 	)
@@ -9981,6 +11090,10 @@
 		(uuid "6acfd775-91ea-46f5-bd4a-237fc61cf4d4")
 	)
 	(no_connect
+		(at 389.89 146.05)
+		(uuid "6b15f701-95d9-4c28-a920-61bd9201b704")
+	)
+	(no_connect
 		(at 133.35 109.22)
 		(uuid "6d84afaa-f5af-4aea-88bb-4973fc79a1f8")
 	)
@@ -9997,6 +11110,10 @@
 		(uuid "709d193a-64ff-4ded-8bdb-6214f05b73d7")
 	)
 	(no_connect
+		(at 389.89 140.97)
+		(uuid "74ea4bc5-35b4-4b61-9d8f-c10426ee0b17")
+	)
+	(no_connect
 		(at 62.23 149.86)
 		(uuid "7626e052-6437-4a05-93d3-8c49d004a25e")
 	)
@@ -10005,8 +11122,16 @@
 		(uuid "77e0a9be-6257-4b3c-80d7-32ac6f9369a6")
 	)
 	(no_connect
+		(at 389.89 173.99)
+		(uuid "78484a9e-cca2-44c9-8188-949f4a8a1216")
+	)
+	(no_connect
 		(at 133.35 121.92)
 		(uuid "7902567d-ec1e-4d79-a79b-e0b7e17f74d2")
+	)
+	(no_connect
+		(at 389.89 189.23)
+		(uuid "79a5fe83-cb0a-4517-bf2c-7dba55b5021e")
 	)
 	(no_connect
 		(at 133.35 50.8)
@@ -10041,6 +11166,14 @@
 		(uuid "83cc368f-f16a-4261-8aef-d6ff4fbbce8f")
 	)
 	(no_connect
+		(at 389.89 125.73)
+		(uuid "87fd79bc-3444-4f28-9ed0-3f4b413952c2")
+	)
+	(no_connect
+		(at 389.89 166.37)
+		(uuid "8940f5d9-e15f-4dfb-a6b5-12e3d1f560d0")
+	)
+	(no_connect
 		(at 62.23 76.2)
 		(uuid "8e565550-1b7c-49a8-8e93-5a5b6a93c3bc")
 	)
@@ -10067,6 +11200,10 @@
 	(no_connect
 		(at 133.35 180.34)
 		(uuid "9d4ebada-7931-483e-85c0-58ee329d2b9d")
+	)
+	(no_connect
+		(at 389.89 186.69)
+		(uuid "9d78e40d-8a46-4996-a932-847040daf1d2")
 	)
 	(no_connect
 		(at 62.23 71.12)
@@ -10117,6 +11254,10 @@
 		(uuid "b4a7bb59-8ca2-4d9f-8d20-b547fd816354")
 	)
 	(no_connect
+		(at 389.89 171.45)
+		(uuid "b83ebad2-9544-4aab-bce5-0a67e34eed87")
+	)
+	(no_connect
 		(at 62.23 152.4)
 		(uuid "b8dcc6a2-e20a-447d-8589-63884c39755b")
 	)
@@ -10163,10 +11304,6 @@
 	(no_connect
 		(at 62.23 180.34)
 		(uuid "dc18eec1-c0c9-4142-a050-7043304fccc3")
-	)
-	(no_connect
-		(at 133.35 83.82)
-		(uuid "dfdeab11-1d91-45f1-9086-083277a37548")
 	)
 	(no_connect
 		(at 62.23 88.9)
@@ -10222,6 +11359,16 @@
 	)
 	(wire
 		(pts
+			(xy 133.35 86.36) (xy 137.16 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "008a7478-0177-463b-9763-ea1de58e6756")
+	)
+	(wire
+		(pts
 			(xy 54.61 210.82) (xy 54.61 214.63)
 		)
 		(stroke
@@ -10259,6 +11406,16 @@
 			(type default)
 		)
 		(uuid "03d4e4d3-b3c8-4aff-9a59-b5503368d732")
+	)
+	(wire
+		(pts
+			(xy 378.46 194.31) (xy 389.89 194.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "04d9154d-e85e-4699-972d-acee7be09fa0")
 	)
 	(wire
 		(pts
@@ -10319,6 +11476,16 @@
 			(type default)
 		)
 		(uuid "07728680-8d01-455f-a2aa-be1efd28b005")
+	)
+	(wire
+		(pts
+			(xy 373.38 196.85) (xy 373.38 199.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "085b90e3-0346-45c4-9c2b-ae0cb3bc5d30")
 	)
 	(wire
 		(pts
@@ -10602,6 +11769,16 @@
 	)
 	(wire
 		(pts
+			(xy 381 138.43) (xy 389.89 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d9767b2-53ee-4800-a084-23d44917a644")
+	)
+	(wire
+		(pts
 			(xy 199.39 171.45) (xy 199.39 163.83)
 		)
 		(stroke
@@ -10679,6 +11856,16 @@
 			(type default)
 		)
 		(uuid "2514f7a3-6b1b-4a0a-b7a9-45b3036dd1c9")
+	)
+	(wire
+		(pts
+			(xy 378.46 158.75) (xy 378.46 161.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "25d61785-f385-44e0-9466-8162ddfdebaa")
 	)
 	(wire
 		(pts
@@ -10789,6 +11976,16 @@
 			(type default)
 		)
 		(uuid "3092b6a6-4400-452d-a599-a010d85da604")
+	)
+	(wire
+		(pts
+			(xy 378.46 130.81) (xy 378.46 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30be8e1a-9ae8-4eb6-87da-e278837495d2")
 	)
 	(wire
 		(pts
@@ -11102,6 +12299,16 @@
 	)
 	(wire
 		(pts
+			(xy 378.46 134.62) (xy 378.46 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "48305db6-1d6f-4e61-8e13-5b88eadd5aac")
+	)
+	(wire
+		(pts
 			(xy 82.55 31.75) (xy 82.55 33.02)
 		)
 		(stroke
@@ -11109,6 +12316,16 @@
 			(type default)
 		)
 		(uuid "48409991-1218-4734-af31-0705f249a855")
+	)
+	(wire
+		(pts
+			(xy 373.38 199.39) (xy 389.89 199.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "48ae29c3-ec71-4f95-b9e7-f94ddea0a4ad")
 	)
 	(wire
 		(pts
@@ -11129,6 +12346,16 @@
 			(type default)
 		)
 		(uuid "4a1a45c1-bb8c-47c5-a945-f813d449f697")
+	)
+	(wire
+		(pts
+			(xy 378.46 191.77) (xy 389.89 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4ac4daf0-9331-4ba7-ab17-c7ca8f6c8ea5")
 	)
 	(wire
 		(pts
@@ -11159,6 +12386,16 @@
 			(type default)
 		)
 		(uuid "4d0123d0-5508-48be-9597-d767e89e1d88")
+	)
+	(wire
+		(pts
+			(xy 381 135.89) (xy 389.89 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4eae97a1-c7fd-472e-8a40-836280c1b931")
 	)
 	(wire
 		(pts
@@ -11229,6 +12466,16 @@
 			(type default)
 		)
 		(uuid "55a8b4ba-850c-45cd-963b-4d4601066c51")
+	)
+	(wire
+		(pts
+			(xy 378.46 161.29) (xy 378.46 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "56a6ecaf-7304-4dd6-b5a9-b6886918d598")
 	)
 	(wire
 		(pts
@@ -11382,6 +12629,26 @@
 	)
 	(wire
 		(pts
+			(xy 373.38 196.85) (xy 389.89 196.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62468379-6829-41ee-b628-6af2fd32fc53")
+	)
+	(wire
+		(pts
+			(xy 384.81 181.61) (xy 389.89 181.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62b926d9-d243-4472-9198-15c78ba2fc43")
+	)
+	(wire
+		(pts
 			(xy 339.09 107.95) (xy 340.36 107.95)
 		)
 		(stroke
@@ -11409,6 +12676,16 @@
 			(type default)
 		)
 		(uuid "654d76e3-ff8f-4231-ad82-9efb38a7ded8")
+	)
+	(wire
+		(pts
+			(xy 378.46 133.35) (xy 389.89 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "65981f49-8864-4263-878a-bc57d1d3160c")
 	)
 	(wire
 		(pts
@@ -11532,6 +12809,16 @@
 	)
 	(wire
 		(pts
+			(xy 389.89 130.81) (xy 378.46 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "71d7773d-f205-4412-8ff9-2dbb7e6cbaa5")
+	)
+	(wire
+		(pts
 			(xy 21.59 26.67) (xy 21.59 30.48)
 		)
 		(stroke
@@ -11629,6 +12916,16 @@
 			(type default)
 		)
 		(uuid "799ffa09-0441-45b9-8fbb-e23ec46d888e")
+	)
+	(wire
+		(pts
+			(xy 379.73 151.13) (xy 389.89 151.13)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a2624cf-2ae6-4818-aa5c-4d22f898db6a")
 	)
 	(wire
 		(pts
@@ -11732,6 +13029,16 @@
 	)
 	(wire
 		(pts
+			(xy 378.46 176.53) (xy 378.46 179.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "846d2b85-6536-4f04-924f-f81b2f596f09")
+	)
+	(wire
+		(pts
 			(xy 278.13 74.93) (xy 278.13 73.66)
 		)
 		(stroke
@@ -11809,6 +13116,16 @@
 			(type default)
 		)
 		(uuid "8b9fb363-7dcc-4324-8121-c0ec5f965ecc")
+	)
+	(wire
+		(pts
+			(xy 378.46 191.77) (xy 378.46 194.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c2accb0-8a75-4bdf-885f-2f2f5ce00f4e")
 	)
 	(wire
 		(pts
@@ -12132,6 +13449,26 @@
 	)
 	(wire
 		(pts
+			(xy 133.35 83.82) (xy 137.16 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d85be93-e5b7-4191-8123-ab8a06945cfe")
+	)
+	(wire
+		(pts
+			(xy 373.38 191.77) (xy 373.38 196.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9dfcb9bf-f5c0-49fe-9f30-933f6fb27201")
+	)
+	(wire
+		(pts
 			(xy 97.79 31.75) (xy 97.79 33.02)
 		)
 		(stroke
@@ -12149,6 +13486,16 @@
 			(type default)
 		)
 		(uuid "9ef10081-9180-47b7-8dee-10a564550f8c")
+	)
+	(wire
+		(pts
+			(xy 374.65 153.67) (xy 389.89 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f2484f4-95fb-4f1b-aec8-af77aaf87919")
 	)
 	(wire
 		(pts
@@ -12209,6 +13556,16 @@
 			(type default)
 		)
 		(uuid "a2b1ead3-b037-4740-987d-ab13b86f8e39")
+	)
+	(wire
+		(pts
+			(xy 378.46 158.75) (xy 389.89 158.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2bfef52-3e6b-4d23-b975-fd71e7b44445")
 	)
 	(wire
 		(pts
@@ -12352,6 +13709,16 @@
 	)
 	(wire
 		(pts
+			(xy 384.81 184.15) (xy 389.89 184.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aaef3533-c02a-47fd-8f07-0ce19b2b17fc")
+	)
+	(wire
+		(pts
 			(xy 31.75 52.07) (xy 30.48 52.07)
 		)
 		(stroke
@@ -12359,6 +13726,16 @@
 			(type default)
 		)
 		(uuid "adbffa65-6c1a-4f91-9277-81e03fc60a50")
+	)
+	(wire
+		(pts
+			(xy 378.46 176.53) (xy 389.89 176.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aecf5382-5224-4362-a6f7-0bf7a34e0a62")
 	)
 	(wire
 		(pts
@@ -12389,6 +13766,16 @@
 			(type default)
 		)
 		(uuid "b1b1b0a4-2bb3-4f4c-82d3-bf2ce46bb45f")
+	)
+	(wire
+		(pts
+			(xy 386.08 143.51) (xy 389.89 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b34cf6d7-60e3-428e-b6ac-be7fe9ac2667")
 	)
 	(wire
 		(pts
@@ -12582,6 +13969,16 @@
 	)
 	(wire
 		(pts
+			(xy 378.46 179.07) (xy 378.46 180.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c250d15a-e6db-4b6e-a5e6-eaee34466ad6")
+	)
+	(wire
+		(pts
 			(xy 361.95 71.12) (xy 360.68 71.12)
 		)
 		(stroke
@@ -12619,6 +14016,16 @@
 			(type default)
 		)
 		(uuid "c44a0107-280d-49ef-8b0e-01f1a622d9f5")
+	)
+	(wire
+		(pts
+			(xy 386.08 168.91) (xy 389.89 168.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c52d7377-e941-4b68-b468-b5fd2209fdae")
 	)
 	(wire
 		(pts
@@ -12752,6 +14159,16 @@
 	)
 	(wire
 		(pts
+			(xy 378.46 179.07) (xy 389.89 179.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ced49aef-b2f5-465e-a3b5-061541376e89")
+	)
+	(wire
+		(pts
 			(xy 278.13 100.33) (xy 276.86 100.33)
 		)
 		(stroke
@@ -12869,6 +14286,16 @@
 			(type default)
 		)
 		(uuid "d3ebfaf5-f665-464f-81b6-08631da0036f")
+	)
+	(wire
+		(pts
+			(xy 386.08 156.21) (xy 389.89 156.21)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4e1310f-f9aa-4e9f-bfc6-a05a9b33b3c4")
 	)
 	(wire
 		(pts
@@ -12992,6 +14419,16 @@
 	)
 	(wire
 		(pts
+			(xy 374.65 151.13) (xy 374.65 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc178610-b92b-4644-b30b-c056cb7d62ce")
+	)
+	(wire
+		(pts
 			(xy 278.13 73.66) (xy 276.86 73.66)
 		)
 		(stroke
@@ -13069,6 +14506,16 @@
 			(type default)
 		)
 		(uuid "e4926af1-dd30-4bd5-9ab9-cd93b3c4a97d")
+	)
+	(wire
+		(pts
+			(xy 378.46 161.29) (xy 389.89 161.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5c21b84-91dc-4b40-be56-b9337c93030e")
 	)
 	(wire
 		(pts
@@ -13584,6 +15031,17 @@
 		)
 		(uuid "223c56f5-bf69-49b4-a601-ca528ad3e9e3")
 	)
+	(label "CANL"
+		(at 389.89 181.61 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "25d2e74b-9fc0-46f8-b33c-56b54f401b16")
+	)
 	(label "MOSI"
 		(at 340.36 73.66 180)
 		(fields_autoplaced yes)
@@ -13716,6 +15174,17 @@
 		)
 		(uuid "44a098a5-f94c-400c-a862-d23d3faf24f7")
 	)
+	(label "ARM"
+		(at 133.35 83.82 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "45c6bbcd-7311-4fac-a21e-393f6a2a1604")
+	)
 	(label "MISO"
 		(at 256.54 102.87 180)
 		(fields_autoplaced yes)
@@ -13826,6 +15295,17 @@
 		)
 		(uuid "6200fca4-7e2b-4b1d-b4aa-1cdaee3953a2")
 	)
+	(label "TX_RADIO"
+		(at 389.89 135.89 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "696c4bb2-23c4-41c1-8a8c-126aa860c0ab")
+	)
 	(label "DRDY_MAG"
 		(at 133.35 233.68 0)
 		(fields_autoplaced yes)
@@ -13847,6 +15327,17 @@
 			(justify right bottom)
 		)
 		(uuid "72882cfe-5c84-4a6f-9ee8-ff8c04bb88f7")
+	)
+	(label "PPS"
+		(at 389.89 156.21 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7568ed75-c989-455f-92fa-af30e77b8229")
 	)
 	(label "MISO"
 		(at 62.23 63.5 180)
@@ -13903,6 +15394,17 @@
 		)
 		(uuid "84f1c939-8938-4001-90f4-3bb931a04878")
 	)
+	(label "RX_RADIO"
+		(at 389.89 138.43 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "885f78cf-225d-4a2f-8bac-6fd804c95ff3")
+	)
 	(label "INT_ACCEL_LOW_1"
 		(at 276.86 90.17 0)
 		(fields_autoplaced yes)
@@ -13924,6 +15426,17 @@
 			(justify left bottom)
 		)
 		(uuid "90180741-50c9-472b-a955-e7af92b91295")
+	)
+	(label "ARM"
+		(at 389.89 143.51 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "9a35d3be-fc03-4410-97f9-c5bcbe8c613b")
 	)
 	(label "TDO"
 		(at 38.1 245.11 0)
@@ -14178,6 +15691,17 @@
 		)
 		(uuid "d4414a04-0c9b-4f8b-a628-d6cadc91c576")
 	)
+	(label "PPS"
+		(at 133.35 86.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d4ebec01-17c8-4500-827d-c428d0f78334")
+	)
 	(label "CS_ACCEL_HIGH"
 		(at 256.54 73.66 180)
 		(fields_autoplaced yes)
@@ -14254,6 +15778,17 @@
 			(justify left bottom)
 		)
 		(uuid "e2e8debb-b62d-49ed-b70e-19403c1557ff")
+	)
+	(label "CANH"
+		(at 389.89 184.15 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "e3289abf-334b-459d-a4cd-533ce3477948")
 	)
 	(label "BOOT"
 		(at 20.32 49.53 180)
@@ -14617,6 +16152,71 @@
 			(project ""
 				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
 					(reference "C22")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 378.46 191.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "11f6411d-a775-45d8-a24b-0e3f28de4051")
+		(property "Reference" "#PWR056"
+			(at 378.46 195.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 378.46 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 378.46 191.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 378.46 191.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 378.46 191.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cd51ab8c-2ac2-42cd-9330-ad8f682a1cb0")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR056")
 					(unit 1)
 				)
 			)
@@ -15275,6 +16875,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+5V")
+		(at 386.08 168.91 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1fa66d33-f3a4-412b-bf90-e54ca7b3f904")
+		(property "Reference" "#PWR053"
+			(at 386.08 172.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 386.08 163.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 386.08 168.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 386.08 168.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 386.08 168.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "06e5822a-90f0-4555-a20c-610dba182fdd")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR053")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:C")
 		(at 54.61 218.44 0)
 		(unit 1)
@@ -15338,6 +17004,159 @@
 			(project "blaze_sense"
 				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
 					(reference "C33")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x30")
+		(at 394.97 161.29 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "29a274eb-5bdc-40c8-ac60-5c2d8c9d21ce")
+		(property "Reference" "J2"
+			(at 397.51 161.2899 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x30"
+			(at 398.78 174.498 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 394.97 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 394.97 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x30, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 394.97 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "5"
+			(uuid "672a967b-0956-4bbd-99d8-e2112b1696dc")
+		)
+		(pin "20"
+			(uuid "a8976249-423a-44b4-915f-5af1fb7f5e05")
+		)
+		(pin "24"
+			(uuid "6e51d381-f7c5-4ce6-a58d-a738da418d0b")
+		)
+		(pin "7"
+			(uuid "f22cba7c-0a5b-4f97-9d23-d07a6656f187")
+		)
+		(pin "4"
+			(uuid "ad01dd16-09d0-4000-85b7-7f86d2ba91e7")
+		)
+		(pin "3"
+			(uuid "1cee8f85-d608-46b5-84c8-d1beb6502051")
+		)
+		(pin "22"
+			(uuid "655cf7e0-dc84-497f-aa3a-69d3988a4d6a")
+		)
+		(pin "16"
+			(uuid "51db743e-1cff-4adb-860d-53ac56e417c7")
+		)
+		(pin "23"
+			(uuid "0f5f2414-5e3e-4a83-8fe8-255fb217e78e")
+		)
+		(pin "21"
+			(uuid "6b9edf47-d20c-4caf-8122-bc57a82f3528")
+		)
+		(pin "2"
+			(uuid "194350ba-ae99-43e0-9a21-4db76dd6c266")
+		)
+		(pin "29"
+			(uuid "ccc530c0-75be-4620-a486-7a737025528a")
+		)
+		(pin "15"
+			(uuid "ace80f76-6b0a-4de4-8747-b87d0ba9e3c2")
+		)
+		(pin "25"
+			(uuid "90819c78-7ca5-4dbd-8def-e25ce9f4b672")
+		)
+		(pin "6"
+			(uuid "f282b8ee-d116-41b3-9583-6f839e4abe41")
+		)
+		(pin "1"
+			(uuid "ad92a6ac-cfa2-4029-993a-38db6b7b6199")
+		)
+		(pin "12"
+			(uuid "4021f127-b268-4076-8b5f-8bc022c9167a")
+		)
+		(pin "11"
+			(uuid "14957dc3-0d6e-4887-8e41-1c307489da53")
+		)
+		(pin "8"
+			(uuid "bcc0250f-ef25-4f97-bec3-cf6bbcd794f5")
+		)
+		(pin "10"
+			(uuid "3e593d31-5539-4848-928d-72bc8be99361")
+		)
+		(pin "13"
+			(uuid "b39a298c-cb8d-41c9-9118-193a21b882cb")
+		)
+		(pin "17"
+			(uuid "ebd501b5-299f-4c1b-8080-581d55372e55")
+		)
+		(pin "26"
+			(uuid "de7dbe13-3985-4fcc-8d46-652810c1253f")
+		)
+		(pin "28"
+			(uuid "24ecb045-f741-42a1-aa59-e95e3c7de290")
+		)
+		(pin "18"
+			(uuid "d896f391-1d3d-49d8-abbf-a2d5e7f9a876")
+		)
+		(pin "19"
+			(uuid "b6a70140-433a-41a4-a07c-a74b37437d88")
+		)
+		(pin "9"
+			(uuid "c9b9d4e8-e1c6-4fcc-bfa5-56c5cc9875d2")
+		)
+		(pin "14"
+			(uuid "3556a372-90a0-4e74-a117-87c784823c99")
+		)
+		(pin "27"
+			(uuid "02bf423d-8ef8-4eaa-be92-d14bfe1524f1")
+		)
+		(pin "30"
+			(uuid "f2575bd1-79ca-417b-8cfd-9d582969760d")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "J2")
 					(unit 1)
 				)
 			)
@@ -15429,6 +17248,72 @@
 			(project "blaze_sense"
 				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
 					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 374.65 151.13 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2dbd24e1-a191-4368-b5ac-99324f3bb492")
+		(property "Reference" "#PWR050"
+			(at 374.65 154.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 374.65 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 374.65 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 374.65 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 374.65 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8d3c180b-f2c5-4124-a5e1-ce7f0d7be397")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR050")
 					(unit 1)
 				)
 			)
@@ -17638,6 +19523,72 @@
 	)
 	(symbol
 		(lib_id "power:GND")
+		(at 378.46 162.56 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "790ed82c-7c39-42a5-8cb8-af80070e0ea9")
+		(property "Reference" "#PWR052"
+			(at 378.46 168.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 378.46 167.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 378.46 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 378.46 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 378.46 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6c82be5a-88fd-43d0-b655-1dfbde2c41fc")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR052")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
 		(at 240.03 96.52 0)
 		(unit 1)
 		(exclude_from_sim no)
@@ -18097,6 +20048,72 @@
 			(project "blaze_sense"
 				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
 					(reference "#PWR020")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 379.73 151.13 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86752ee8-8e81-4a60-a71f-f446031fce86")
+		(property "Reference" "#PWR051"
+			(at 379.73 154.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+5V"
+			(at 379.73 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 379.73 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 379.73 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 379.73 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4ac70680-6ac1-42ad-9b1d-fd4c64fcaf0f")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR051")
 					(unit 1)
 				)
 			)
@@ -19238,6 +21255,71 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 378.46 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a55ed13e-3ad6-48e1-9c52-9ea7d733fbb7")
+		(property "Reference" "#PWR054"
+			(at 378.46 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 378.46 184.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 378.46 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 378.46 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 378.46 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a4d9f715-846c-4087-9ffd-9d092854f507")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR054")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:C")
 		(at 179.07 26.67 0)
 		(unit 1)
@@ -20003,6 +22085,72 @@
 			(project "blaze_sense"
 				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
 					(reference "C31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 378.46 134.62 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba02ae9a-9228-4cc1-9277-92707196e509")
+		(property "Reference" "#PWR049"
+			(at 378.46 140.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 378.46 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 378.46 134.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 378.46 134.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 378.46 134.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b644908c-6b77-4a93-bc37-0e389a1d9157")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR049")
 					(unit 1)
 				)
 			)
@@ -20958,6 +23106,72 @@
 			(project "blaze_sense"
 				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
 					(reference "C14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 373.38 191.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dbb7c295-87d4-4ddf-989a-f83b5e08cad8")
+		(property "Reference" "#PWR055"
+			(at 373.38 195.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 373.38 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 373.38 191.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 373.38 191.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+5V\""
+			(at 373.38 191.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5fcad021-a886-4354-82ea-8a9c91ec42f4")
+		)
+		(instances
+			(project "blaze_sense"
+				(path "/8798ba42-980c-4c88-8e33-275ab3ef733e"
+					(reference "#PWR055")
 					(unit 1)
 				)
 			)


### PR DESCRIPTION
Implemented changes to interconnect ratified in last meeting. Audio and neopixel were found to be unused and thus removed from the interconnect. Redundant can was removed as the microcontrollers don't support a second CAN interface.